### PR TITLE
backend: add observer and metrics interceptor

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -70,6 +70,30 @@ r.Use(observerInterceptor.WrapHandler)
 userSvcPath, userSvcHandler := dataplanev1alpha1connect.NewUserServiceHandler(userSvc, connect.WithInterceptors(observerInterceptor))
 ```
 
+## Package metrics
+
+The metrics package offers features that streamline the process of instrumenting your API server.
+It works alongside the observerInterceptor that is implemented as part of the interceptor package.
+
+```go
+apiProm, err := metrics.NewPrometheus(
+    metrics.WithRegistry(prometheus.DefaultRegisterer),
+    metrics.WithDynamicLabel("test", func(ctx context.Context, metadata *redpandainterceptor.RequestMetadata) string {
+        return "val"
+    }),
+)
+if err != nil {
+    api.Logger.Fatal("failed to create prometheus adapter", zap.Error(err))
+}
+
+// Mount observer interceptor before
+observerInterceptor := redpandainterceptor.NewObserver(apiProm.ObserverAdapter())
+
+// You must mount both HTTP middleware and connectrpc interceptors
+r.Use(observerInterceptor.WrapHandler)
+userSvcPath, userSvcHandler := dataplanev1alpha1connect.NewUserServiceHandler(userSvc, connect.WithInterceptors(observerInterceptor))
+```
+
 ## Package pagination
 
 The package pagination provides functions for handling paginated Redpanda API

--- a/api/go.mod
+++ b/api/go.mod
@@ -7,15 +7,23 @@ require (
 	connectrpc.com/connect v1.15.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240125205218-1f4bbc51befe
-	google.golang.org/grpc v1.62.0
+	google.golang.org/grpc v1.62.1
 	google.golang.org/protobuf v1.33.0
 )
 
 require (
+	buf.build/gen/go/connectrpc/eliza/connectrpc/go v1.15.0-20230913231627-233fca715f49.1 // indirect
+	buf.build/gen/go/connectrpc/eliza/protocolbuffers/go v1.33.0-20230913231627-233fca715f49.1 // indirect
 	buf.build/gen/go/redpandadata/common/connectrpc/go v1.15.0-20240308150626-33e02aaad4d0.1 // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/prometheus/client_golang v1.19.0 // indirect
+	github.com/prometheus/client_model v0.5.0 // indirect
+	github.com/prometheus/common v0.48.0 // indirect
+	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/stretchr/testify v1.9.0 // indirect
 	golang.org/x/net v0.21.0 // indirect
 	golang.org/x/sys v0.17.0 // indirect

--- a/api/go.sum
+++ b/api/go.sum
@@ -1,4 +1,8 @@
 buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.32.0-20230914171853-63dfe56cc2c4.1/go.mod h1:tiTMKD8j6Pd/D2WzREoweufjzaJKHZg35f/VGcZ2v3I=
+buf.build/gen/go/connectrpc/eliza/connectrpc/go v1.15.0-20230913231627-233fca715f49.1 h1:F1ZMhxV6+MRxWtc1aT+vH9+yZLB4KrhlhQmtuDxqTYQ=
+buf.build/gen/go/connectrpc/eliza/connectrpc/go v1.15.0-20230913231627-233fca715f49.1/go.mod h1:OZPBPnAuuFcUf5WHYm5pIXkUhIy7Pp6dzV4W2Zbc2/c=
+buf.build/gen/go/connectrpc/eliza/protocolbuffers/go v1.33.0-20230913231627-233fca715f49.1 h1:bHffCjg+jKMaDnUeYjBJXHAlH659fX4N1YExnWl5wFU=
+buf.build/gen/go/connectrpc/eliza/protocolbuffers/go v1.33.0-20230913231627-233fca715f49.1/go.mod h1:v0PWlly2hqVEW2IZSPlvPHELTvdHD5hBsA0+KlCfTQk=
 buf.build/gen/go/redpandadata/common/connectrpc/go v1.15.0-20240308150626-33e02aaad4d0.1 h1:39DZLLwfYhrxvgsMG7zxUZ/9botT3rs3MsKHmjrxoEU=
 buf.build/gen/go/redpandadata/common/connectrpc/go v1.15.0-20240308150626-33e02aaad4d0.1/go.mod h1:M95CSPuqYUr82kgoxjLG0gFy2E4XTBEf+NLQcgqqlFg=
 buf.build/gen/go/redpandadata/common/protocolbuffers/go v1.32.0-20240130111152-723ec1649aaa.1 h1:WQVOTW6QIYPBHuwfwe+CMdMJ0YvjO/CF29ZEXr2zvvE=
@@ -9,6 +13,10 @@ buf.build/gen/go/redpandadata/common/protocolbuffers/go v1.33.0-20240308150626-3
 buf.build/gen/go/redpandadata/common/protocolbuffers/go v1.33.0-20240308150626-33e02aaad4d0.1/go.mod h1:NDWpeU3ohHVIKP3DhrDOtnLrmrjz8il/5SH+1/B6TNM=
 connectrpc.com/connect v1.15.0 h1:lFdeCbZrVVDydAqwr4xGV2y+ULn+0Z73s5JBj2LikWo=
 connectrpc.com/connect v1.15.0/go.mod h1:bQmjpDY8xItMnttnurVgOkHUBMRT9cpsNi2O4AjKhmA=
+github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
+github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
+github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
@@ -21,6 +29,14 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1 h1:/c3QmbOGMGTOumP2iT/rCwB7b0Q
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1/go.mod h1:5SN9VR2LTsRFsrEC6FHgRbTWrTHu6tqPeKxEQv15giM=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/prometheus/client_golang v1.19.0 h1:ygXvpU1AoN1MhdzckN+PyD9QJOSD4x7kmXYlnfbA6JU=
+github.com/prometheus/client_golang v1.19.0/go.mod h1:ZRM9uEAypZakd+q/x7+gmsvXdURP+DABIEIjnmDdp+k=
+github.com/prometheus/client_model v0.5.0 h1:VQw1hfvPvk3Uv6Qf29VrPF32JB6rtbgI6cYPYQjL0Qw=
+github.com/prometheus/client_model v0.5.0/go.mod h1:dTiFglRmd66nLR9Pv9f0mZi7B7fk5Pm3gvsjB5tr+kI=
+github.com/prometheus/common v0.48.0 h1:QO8U2CdOzSn1BBsmXJXduaaW+dY/5QLjfB8svtSzKKE=
+github.com/prometheus/common v0.48.0/go.mod h1:0/KsvlIEfPQCQ5I2iNSAWKPZziNCvRs5EC6ILDTlAPc=
+github.com/prometheus/procfs v0.12.0 h1:jluTpSng7V9hY0O2R9DzzJHYb2xULk9VTR1V1R/k6Bo=
+github.com/prometheus/procfs v0.12.0/go.mod h1:pcuDEFsWDnvcgNzo4EEweacyhjeA9Zk3cnaOZAZEfOo=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 golang.org/x/net v0.21.0 h1:AQyQV4dYCvJ7vGmJyKki9+PBdyvhkSd8EIx/qb0AYv4=
@@ -38,6 +54,8 @@ google.golang.org/genproto/googleapis/rpc v0.0.0-20240125205218-1f4bbc51befe h1:
 google.golang.org/genproto/googleapis/rpc v0.0.0-20240125205218-1f4bbc51befe/go.mod h1:PAREbraiVEVGVdTZsVWjSbbTtSyGbAgIIvni8a8CD5s=
 google.golang.org/grpc v1.62.0 h1:HQKZ/fa1bXkX1oFOvSjmZEUL8wLSaZTjCcLAlmZRtdk=
 google.golang.org/grpc v1.62.0/go.mod h1:IWTG0VlJLCh1SkC58F7np9ka9mx/WNkjl4PGJaiq+QE=
+google.golang.org/grpc v1.62.1 h1:B4n+nfKzOICUXMgyrNd19h/I9oH0L1pizfk1d4zSgTk=
+google.golang.org/grpc v1.62.1/go.mod h1:IWTG0VlJLCh1SkC58F7np9ka9mx/WNkjl4PGJaiq+QE=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.32.0 h1:pPC6BG5ex8PDFnkbrGU3EixyhKcQ2aDuBS36lqK/C7I=

--- a/api/grpcgateway/http_status.go
+++ b/api/grpcgateway/http_status.go
@@ -8,6 +8,8 @@ import (
 
 // ConnectCodeToHTTPStatus converts a connect error code into the corresponding
 // HTTP response status.
+//
+//nolint:cyclop // It's easy enough to understand, just a bunch of switch case.
 func ConnectCodeToHTTPStatus(code connect.Code) int {
 	switch code {
 	case 0:

--- a/api/grpcgateway/http_status.go
+++ b/api/grpcgateway/http_status.go
@@ -1,0 +1,75 @@
+package grpcgateway
+
+import (
+	"net/http"
+
+	"connectrpc.com/connect"
+)
+
+// ConnectCodeToHTTPStatus converts a connect error code into the corresponding
+// HTTP response status.
+func ConnectCodeToHTTPStatus(code connect.Code) int {
+	switch code {
+	case 0:
+		return http.StatusOK
+	case connect.CodeCanceled:
+		return 499
+	case connect.CodeUnknown:
+		return http.StatusInternalServerError
+	case connect.CodeInvalidArgument:
+		return http.StatusBadRequest
+	case connect.CodeDeadlineExceeded:
+		return http.StatusGatewayTimeout
+	case connect.CodeNotFound:
+		return http.StatusNotFound
+	case connect.CodeAlreadyExists:
+		return http.StatusConflict
+	case connect.CodePermissionDenied:
+		return http.StatusForbidden
+	case connect.CodeUnauthenticated:
+		return http.StatusUnauthorized
+	case connect.CodeResourceExhausted:
+		return http.StatusTooManyRequests
+	case connect.CodeFailedPrecondition:
+		// Note, this deliberately doesn't translate to the similarly named '412 Precondition Failed' HTTP response status.
+		return http.StatusBadRequest
+	case connect.CodeAborted:
+		return http.StatusConflict
+	case connect.CodeOutOfRange:
+		return http.StatusBadRequest
+	case connect.CodeUnimplemented:
+		return http.StatusNotImplemented
+	case connect.CodeInternal:
+		return http.StatusInternalServerError
+	case connect.CodeUnavailable:
+		return http.StatusServiceUnavailable
+	case connect.CodeDataLoss:
+		return http.StatusInternalServerError
+	default:
+		return http.StatusInternalServerError
+	}
+}
+
+// HTTPStatusCodeToConnectCode converts an HTTP status code into the
+// corresponding connect response code.
+func HTTPStatusCodeToConnectCode(code int) connect.Code {
+	switch code {
+	case http.StatusOK:
+		return 0 // OK
+	case http.StatusBadRequest:
+		return connect.CodeInternal
+	case http.StatusUnauthorized:
+		return connect.CodeUnauthenticated
+	case http.StatusForbidden:
+		return connect.CodePermissionDenied
+	case http.StatusNotFound:
+		return connect.CodeUnimplemented
+	case http.StatusTooManyRequests,
+		http.StatusBadGateway,
+		http.StatusServiceUnavailable,
+		http.StatusGatewayTimeout:
+		return connect.CodeUnavailable
+	default:
+		return connect.CodeUnknown
+	}
+}

--- a/api/interceptor/interceptor.go
+++ b/api/interceptor/interceptor.go
@@ -1,0 +1,2 @@
+// Package interceptor provides connectrpc compatible interceptors.
+package interceptor

--- a/api/interceptor/observer.go
+++ b/api/interceptor/observer.go
@@ -1,0 +1,269 @@
+package interceptor
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+)
+
+var _ connect.Interceptor = &Observer{}
+
+// Observer wraps all requests/responses and emits events that inform about
+// request duration, size and status code.
+type Observer struct {
+	onRequestEnded func(context.Context, *RequestMetadata)
+}
+
+// NewObserver creates a new Observer.
+func NewObserver(onRequestEnded func(context.Context, *RequestMetadata)) *Observer {
+	return &Observer{
+		onRequestEnded: onRequestEnded,
+	}
+}
+
+// WrapHandler mounts an HTTP middleware to gather metrics at the
+// HTTP level.
+func (in *Observer) WrapHandler(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// 1. Inject request metadata into request context
+		var procedure string
+		switch {
+		case strings.HasPrefix(r.RequestURI, "/grpc.reflection.v1.ServerReflection"),
+			strings.HasPrefix(r.RequestURI, "/grpc.reflection.v1alpha.ServerReflection"):
+			procedure = r.RequestURI
+		default:
+			procedure = "none"
+		}
+		rm := &RequestMetadata{
+			startAt:     time.Now(),
+			peerAddress: r.RemoteAddr,
+			protocol:    "http",
+			procedure:   procedure,
+			requestURI:  r.RequestURI,
+			method:      r.Method,
+			// Other properties are set by wrapped body ready, response writer
+			// as well as connectrpc interceptors.
+		}
+		ctx := setRequestMetadata(r.Context(), rm)
+		r = r.WithContext(ctx)
+
+		// 2. Inject custom body reader that counts the bytes as part of the request
+		r.Body = bodyReader{
+			base:      r.Body,
+			bytesRead: &rm.bytesReceived,
+		}
+
+		// 3. Wrap a response writer to collect metrics while writing the response
+		wrappedResponseWriter := responseController{
+			base: w.(responseWriteFlusher),
+			rm:   rm,
+		}
+
+		// 4. Let handler(s) process the request
+		next.ServeHTTP(wrappedResponseWriter, r)
+
+		// 5. Inform RequestMetadata that we can stop measuring duration
+		rm.end()
+		in.onRequestEnded(r.Context(), rm)
+	})
+}
+
+// WrapUnary creates an interceptor to validate Connect requests.
+func (*Observer) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
+	return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+		if req.Spec().IsClient {
+			return next(ctx, req)
+		}
+
+		rm := getRequestMetadata(ctx)
+
+		// For HTTP paths invoked via gRPC gateway, procedure is expected not to be set.
+		// In that case, let's try to retrieve it with gRPC gateway's runtime pkg.
+		procedure := req.Spec().Procedure
+		if procedure == "" {
+			path, ok := runtime.RPCMethod(ctx)
+			if !ok {
+				procedure = "unknown"
+			} else {
+				procedure = path
+			}
+		}
+		rm.procedure = procedure
+
+		protocol := req.Peer().Protocol
+		if protocol == "" {
+			protocol = "http"
+		}
+		rm.protocol = protocol
+
+		// 2. Execute request
+		response, err := next(ctx, req)
+		rm.err = err
+
+		return response, err
+	}
+}
+
+// WrapStreamingClient is the middleware handler for bidirectional requests from
+// the client perspective.
+func (*Observer) WrapStreamingClient(next connect.StreamingClientFunc) connect.StreamingClientFunc {
+	return next
+}
+
+// WrapStreamingHandler is the middleware handler for bidirectional requests from
+// the server handling perspective.
+func (*Observer) WrapStreamingHandler(next connect.StreamingHandlerFunc) connect.StreamingHandlerFunc {
+	return func(ctx context.Context, stream connect.StreamingHandlerConn) error {
+		rm := getRequestMetadata(ctx)
+		rm.procedure = stream.Spec().Procedure
+		rm.protocol = stream.Peer().Protocol
+
+		wrapped := streamingHandlerConn{
+			base: stream,
+			rm:   rm,
+		}
+		if err := next(ctx, wrapped); err != nil {
+			rm.err = err
+			return err
+		}
+		return nil
+	}
+}
+
+// RequestMetadata represents the metadata gathered during the entire lifecycle
+// of an incoming API request.
+type RequestMetadata struct {
+	startAt          time.Time
+	finishedAt       time.Time
+	duration         time.Duration
+	procedure        string
+	requestURI       string
+	method           string
+	protocol         string
+	peerAddress      string
+	messagesReceived int
+	messagesSent     int
+	bytesReceived    int64
+	bytesSent        int64
+	httpStatusCode   int
+	err              error
+}
+
+// StartAt retrieves the timestamp indicating when the server received the
+// request.
+func (r *RequestMetadata) StartAt() time.Time {
+	return r.startAt
+}
+
+// FinishedAt retrieves the timestamp indicating when the server completed
+// processing the request.
+func (r *RequestMetadata) FinishedAt() time.Time {
+	return r.finishedAt
+}
+
+// Duration returns the duration of the request processing.
+func (r *RequestMetadata) Duration() time.Duration {
+	return r.duration
+}
+
+// Procedure returns the RPC name.
+func (r *RequestMetadata) Procedure() string {
+	return r.procedure
+}
+
+// RequestURI returns the HTTP request uri.
+func (r *RequestMetadata) RequestURI() string {
+	return r.requestURI
+}
+
+// Method returns the HTTP method.
+func (r *RequestMetadata) Method() string {
+	return r.method
+}
+
+// Protocol returns the protocol that was used (e.g. grpc, connect, http).
+func (r *RequestMetadata) Protocol() string {
+	return r.protocol
+}
+
+// PeerAddress returns the IP address of the requester.
+func (r *RequestMetadata) PeerAddress() string {
+	return r.peerAddress
+}
+
+// MessagesReceived returns the number of messages received
+// in a streaming request.
+func (r *RequestMetadata) MessagesReceived() int {
+	return r.messagesReceived
+}
+
+// MessagesSent returns the number of messages sent
+// in a streaming request.
+func (r *RequestMetadata) MessagesSent() int {
+	return r.messagesSent
+}
+
+// BytesReceived is the number of bytes we read via HTTP.
+func (r *RequestMetadata) BytesReceived() int64 {
+	return r.bytesReceived
+}
+
+// BytesSent is the number of bytes we sent via HTTP.
+func (r *RequestMetadata) BytesSent() int64 {
+	return r.bytesSent
+}
+
+// HTTPStatusCode returns the HTTP status code. This is expected to be 200 for
+// most gRPC and connectrpc requests.
+func (r *RequestMetadata) HTTPStatusCode() int {
+	return r.httpStatusCode
+}
+
+// StatusCode returns the response status code in a string presentation.
+// If there was no error the status code "ok" will be returned.
+func (r *RequestMetadata) StatusCode() string {
+	if r.procedure == "none" && r.protocol == "http" {
+		switch r.httpStatusCode {
+		case http.StatusOK:
+			return "ok"
+		case http.StatusNotFound:
+			return connect.CodeNotFound.String()
+		case http.StatusRequestTimeout:
+			return connect.CodeCanceled.String()
+		case http.StatusBadRequest:
+			return connect.CodeInvalidArgument.String()
+		default:
+			return connect.CodeInternal.String()
+		}
+	}
+
+	if r.err == nil {
+		return "ok"
+	}
+	return connect.CodeOf(r.err).String()
+}
+
+// Err returns the error that was returned by a handler.
+func (r *RequestMetadata) Err() error {
+	return r.err
+}
+
+func (r *RequestMetadata) end() {
+	r.finishedAt = time.Now()
+	r.duration = time.Since(r.startAt)
+}
+
+type requestMetadataCtxKey struct{}
+
+func setRequestMetadata(ctx context.Context, rm *RequestMetadata) context.Context {
+	return context.WithValue(ctx, requestMetadataCtxKey{}, rm)
+}
+
+func getRequestMetadata(ctx context.Context) *RequestMetadata {
+	//nolint:revive // We are certain that this assertion is okay
+	return ctx.Value(requestMetadataCtxKey{}).(*RequestMetadata)
+}

--- a/api/interceptor/observer.go
+++ b/api/interceptor/observer.go
@@ -8,6 +8,8 @@ import (
 
 	"connectrpc.com/connect"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+
+	"github.com/redpanda-data/common-go/api/grpcgateway"
 )
 
 var _ connect.Interceptor = &Observer{}
@@ -227,18 +229,11 @@ func (r *RequestMetadata) HTTPStatusCode() int {
 // If there was no error the status code "ok" will be returned.
 func (r *RequestMetadata) StatusCode() string {
 	if r.procedure == "none" && r.protocol == "http" {
-		switch r.httpStatusCode {
-		case http.StatusOK:
+		connectCode := grpcgateway.HTTPStatusCodeToConnectCode(r.httpStatusCode)
+		if connectCode == 0 {
 			return "ok"
-		case http.StatusNotFound:
-			return connect.CodeNotFound.String()
-		case http.StatusRequestTimeout:
-			return connect.CodeCanceled.String()
-		case http.StatusBadRequest:
-			return connect.CodeInvalidArgument.String()
-		default:
-			return connect.CodeInternal.String()
 		}
+		return connectCode.String()
 	}
 
 	if r.err == nil {

--- a/api/interceptor/observer_connectrpc.go
+++ b/api/interceptor/observer_connectrpc.go
@@ -1,0 +1,50 @@
+package interceptor
+
+import (
+	"net/http"
+
+	"connectrpc.com/connect"
+)
+
+var _ connect.StreamingHandlerConn = (*streamingHandlerConn)(nil)
+
+type streamingHandlerConn struct {
+	base connect.StreamingHandlerConn
+	rm   *RequestMetadata
+}
+
+func (c streamingHandlerConn) Spec() connect.Spec {
+	return c.base.Spec()
+}
+
+func (c streamingHandlerConn) Peer() connect.Peer {
+	return c.base.Peer()
+}
+
+func (c streamingHandlerConn) RequestHeader() http.Header {
+	return c.base.RequestHeader()
+}
+
+func (c streamingHandlerConn) ResponseHeader() http.Header {
+	return c.base.ResponseHeader()
+}
+
+func (c streamingHandlerConn) ResponseTrailer() http.Header {
+	return c.base.ResponseTrailer()
+}
+
+func (c streamingHandlerConn) Receive(m any) error {
+	if err := c.base.Receive(m); err != nil {
+		return err
+	}
+	c.rm.messagesReceived++
+	return nil
+}
+
+func (c streamingHandlerConn) Send(m any) error {
+	if err := c.base.Send(m); err != nil {
+		return err
+	}
+	c.rm.messagesSent++
+	return nil
+}

--- a/api/interceptor/observer_http.go
+++ b/api/interceptor/observer_http.go
@@ -1,0 +1,56 @@
+package interceptor
+
+import (
+	"io"
+	"net/http"
+)
+
+type bodyReader struct {
+	base      io.ReadCloser
+	bytesRead *int64
+}
+
+func (r bodyReader) Read(p []byte) (int, error) {
+	n, err := r.base.Read(p)
+	*r.bytesRead += int64(n)
+	return n, err
+}
+
+func (r bodyReader) Close() error {
+	return r.base.Close()
+}
+
+type responseWriteFlusher interface {
+	http.ResponseWriter
+	http.Flusher
+}
+
+type responseController struct {
+	base responseWriteFlusher
+	rm   *RequestMetadata
+}
+
+var _ responseWriteFlusher = (*responseController)(nil)
+
+func (r responseController) Header() http.Header {
+	return r.base.Header()
+}
+
+func (r responseController) Write(p []byte) (int, error) {
+	n, err := r.base.Write(p)
+	r.rm.bytesSent += int64(n)
+	return n, err
+}
+
+func (r responseController) WriteHeader(statusCode int) {
+	r.rm.httpStatusCode = statusCode
+	r.base.WriteHeader(statusCode)
+}
+
+func (r responseController) Flush() {
+	r.base.Flush()
+}
+
+func (r responseController) Unwrap() http.ResponseWriter {
+	return r.base
+}

--- a/api/interceptor/observer_test.go
+++ b/api/interceptor/observer_test.go
@@ -109,7 +109,6 @@ func TestObserver(t *testing.T) {
 		assert.Equal(t, nil, serverStreamMetadata.Err())
 		assert.Equal(t, 1, serverStreamMetadata.MessagesReceived())
 		assert.Equal(t, expectedResponses, serverStreamMetadata.MessagesSent())
-
 	})
 }
 

--- a/api/interceptor/observer_test.go
+++ b/api/interceptor/observer_test.go
@@ -1,0 +1,87 @@
+package interceptor_test
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"buf.build/gen/go/connectrpc/eliza/connectrpc/go/connectrpc/eliza/v1/elizav1connect"
+	elizav1 "buf.build/gen/go/connectrpc/eliza/protocolbuffers/go/connectrpc/eliza/v1"
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
+	"google.golang.org/grpc/test/bufconn"
+
+	"github.com/redpanda-data/common-go/api/interceptor"
+)
+
+func TestObserver(t *testing.T) {
+	// Create dummy handler with observer middleware
+	var lastMetadata interceptor.RequestMetadata
+	onRequestEnded := func(_ context.Context, requestMetadata *interceptor.RequestMetadata) {
+		lastMetadata = *requestMetadata
+	}
+	observerMiddleware := interceptor.NewObserver(onRequestEnded)
+
+	mux := http.NewServeMux()
+	mux.Handle(elizav1connect.NewElizaServiceHandler(
+		elizaServerHandler{},
+		connect.WithInterceptors(observerMiddleware),
+	))
+
+	// Below boilerplate can be simplified by using the connect-go
+	// memhttp package once exported. See following
+	// issue: https://github.com/connectrpc/connect-go/issues/694
+
+	// Start HTTP server
+	h2s := &http2.Server{}
+	handler := h2c.NewHandler(observerMiddleware.WrapHandler(mux), h2s)
+	httpServer := http.Server{
+		Handler: handler,
+	}
+	lis := bufconn.Listen(1024 * 1024)
+	go func() {
+		err := httpServer.Serve(lis)
+		require.NoError(t, err)
+	}()
+	time.Sleep(time.Second)
+
+	// Create client
+	httpCl := &http.Client{
+		Transport: &http2.Transport{
+			DialTLSContext: func(ctx context.Context, _ string, _ string, _ *tls.Config) (net.Conn, error) {
+				return lis.DialContext(ctx)
+			},
+			AllowHTTP: true,
+		},
+	}
+	cl := elizav1connect.NewElizaServiceClient(httpCl, "http://"+lis.Addr().String())
+
+	// Send request
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Second)
+	defer cancel()
+	_, err := cl.Say(ctx, connect.NewRequest(&elizav1.SayRequest{Sentence: "hello-test"}))
+	require.NoError(t, err)
+
+	assert.Equal(t, "connect", lastMetadata.Protocol())
+	assert.Equal(t, "ok", lastMetadata.StatusCode())
+	assert.Equal(t, "/connectrpc.eliza.v1.ElizaService/Say", lastMetadata.Procedure())
+	assert.Equal(t, nil, lastMetadata.Err())
+	assert.Equal(t, int64(36), lastMetadata.BytesSent())
+	assert.Equal(t, int64(12), lastMetadata.BytesReceived())
+}
+
+type elizaServerHandler struct {
+	elizav1connect.UnimplementedElizaServiceHandler
+}
+
+func (elizaServerHandler) Say(_ context.Context, req *connect.Request[elizav1.SayRequest]) (*connect.Response[elizav1.SayResponse], error) {
+	return connect.NewResponse(&elizav1.SayResponse{
+		Sentence: req.Msg.Sentence, // Just echo request string
+	}), nil
+}

--- a/api/metrics/options.go
+++ b/api/metrics/options.go
@@ -35,3 +35,10 @@ func WithDynamicLabel(key string, valueGetter func(context.Context, *interceptor
 		p.dynamicLabelFns[key] = valueGetter
 	}
 }
+
+// WithMetricsNamespace can be used to set the metrics namespace for all exported metrics.
+func WithMetricsNamespace(metricsNamespace string) Option {
+	return func(p *Prometheus) {
+		p.metricsNamespace = metricsNamespace
+	}
+}

--- a/api/metrics/options.go
+++ b/api/metrics/options.go
@@ -1,0 +1,37 @@
+package metrics
+
+import (
+	"context"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/redpanda-data/common-go/api/interceptor"
+)
+
+// Option is a functional option type that allows us to configure the Prometheus type.
+type Option func(*Prometheus)
+
+// WithRegistry allows to provide a prometheus registry. If not provided, the default
+// global Prometheus registry will be used.
+func WithRegistry(registry prometheus.Registerer) Option {
+	return func(p *Prometheus) {
+		p.registry = registry
+	}
+}
+
+// WithConstLabels can be used to attach static labels to the exported metrics.
+func WithConstLabels(labels map[string]string) Option {
+	return func(p *Prometheus) {
+		p.constLabels = labels
+	}
+}
+
+// WithDynamicLabel allows adding dynamic labels. The key is the label key
+// and the valueGetter is called for every finished request. Thus, the
+// valueGetter must be safe to be called concurrently. You can add multiple
+// dynamic labels.
+func WithDynamicLabel(key string, valueGetter func(context.Context, *interceptor.RequestMetadata) string) Option {
+	return func(p *Prometheus) {
+		p.dynamicLabelFns[key] = valueGetter
+	}
+}

--- a/api/metrics/prometheus.go
+++ b/api/metrics/prometheus.go
@@ -1,0 +1,75 @@
+// Package metrics provides functionality to instrument your API servers
+// using metrics such as Prometheus.
+package metrics
+
+import (
+	"context"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/redpanda-data/common-go/api/interceptor"
+)
+
+// Prometheus can be used to instrument your API server and collect
+// a standard set of metrics on the server. It is designed to work
+// alongside the interceptor.Observer middleware.
+type Prometheus struct {
+	registry         prometheus.Registerer
+	constLabels      prometheus.Labels
+	metricsNamespace string
+	// dynamicLabelFns can be used to dynamically add label partitions. The key
+	// is the label key and the according function must return the value. The
+	// function must be safe to be called concurrently.
+	dynamicLabelFns map[string]func(context.Context, *interceptor.RequestMetadata) string
+
+	requestDuration *prometheus.HistogramVec
+}
+
+// NewPrometheus creates a new Prometheus instance. If it fails to register
+// a collector an error will be returned.
+func NewPrometheus(opts ...Option) (*Prometheus, error) {
+	p := &Prometheus{
+		dynamicLabelFns: make(map[string]func(context.Context, *interceptor.RequestMetadata) string),
+	}
+	for _, o := range opts {
+		o(p)
+	}
+
+	labelKeys := []string{"procedure", "status"}
+	for key := range p.dynamicLabelFns {
+		labelKeys = append(labelKeys, key)
+	}
+
+	requestDuration := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace:   p.metricsNamespace,
+		Name:        "request_duration_seconds",
+		Help:        "Time (in seconds) spent in serving requests",
+		ConstLabels: p.constLabels,
+		Buckets:     prometheus.DefBuckets,
+	}, labelKeys)
+
+	if p.registry == nil {
+		p.registry = prometheus.DefaultRegisterer
+	}
+	if err := p.registry.Register(requestDuration); err != nil {
+		return nil, err
+	}
+	p.requestDuration = requestDuration
+
+	return p, nil
+}
+
+// ObserverAdapter returns the callback function for an interceptor.Observer.
+// Pass this function to an observer to collect metrics for your API server.
+func (p *Prometheus) ObserverAdapter() func(context.Context, *interceptor.RequestMetadata) {
+	return func(ctx context.Context, rm *interceptor.RequestMetadata) {
+		labels := map[string]string{
+			"procedure": rm.Procedure(),
+			"status":    rm.StatusCode(),
+		}
+		for key, fn := range p.dynamicLabelFns {
+			labels[key] = fn(ctx, rm)
+		}
+		p.requestDuration.With(labels).Observe(rm.Duration().Seconds())
+	}
+}


### PR DESCRIPTION
This PR adds an observer interceptor and a helper 

1. An observer interceptor which observes (streaming) requests from beginning to end and call a provided callback function with stats collected when processing the request
2. A Prometheus helper, which can be used to instrument an API server. It's supposed to be used alongside the observer interceptor to collect metrics.

Example prometheus metrics:

```
# HELP request_duration_seconds Time (in seconds) spent in serving requests
# TYPE request_duration_seconds histogram
request_duration_seconds_bucket{procedure="/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo",status="ok",test="val",le="0.005"} 3
request_duration_seconds_bucket{procedure="/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo",status="ok",test="val",le="0.01"} 4
request_duration_seconds_bucket{procedure="/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo",status="ok",test="val",le="0.025"} 14
request_duration_seconds_bucket{procedure="/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo",status="ok",test="val",le="0.05"} 27
request_duration_seconds_bucket{procedure="/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo",status="ok",test="val",le="0.1"} 30
request_duration_seconds_bucket{procedure="/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo",status="ok",test="val",le="0.25"} 30
request_duration_seconds_bucket{procedure="/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo",status="ok",test="val",le="0.5"} 30
request_duration_seconds_bucket{procedure="/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo",status="ok",test="val",le="1"} 30
request_duration_seconds_bucket{procedure="/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo",status="ok",test="val",le="2.5"} 30
request_duration_seconds_bucket{procedure="/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo",status="ok",test="val",le="5"} 30
request_duration_seconds_bucket{procedure="/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo",status="ok",test="val",le="10"} 30
request_duration_seconds_bucket{procedure="/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo",status="ok",test="val",le="+Inf"} 30
request_duration_seconds_sum{procedure="/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo",status="ok",test="val"} 0.893846333
request_duration_seconds_count{procedure="/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo",status="ok",test="val"} 30
request_duration_seconds_bucket{procedure="/redpanda.api.console.v1alpha1.ConsoleService/ListMessages",status="ok",test="val",le="0.005"} 0
request_duration_seconds_bucket{procedure="/redpanda.api.console.v1alpha1.ConsoleService/ListMessages",status="ok",test="val",le="0.01"} 0
request_duration_seconds_bucket{procedure="/redpanda.api.console.v1alpha1.ConsoleService/ListMessages",status="ok",test="val",le="0.025"} 0
request_duration_seconds_bucket{procedure="/redpanda.api.console.v1alpha1.ConsoleService/ListMessages",status="ok",test="val",le="0.05"} 0
request_duration_seconds_bucket{procedure="/redpanda.api.console.v1alpha1.ConsoleService/ListMessages",status="ok",test="val",le="0.1"} 1
request_duration_seconds_bucket{procedure="/redpanda.api.console.v1alpha1.ConsoleService/ListMessages",status="ok",test="val",le="0.25"} 1
request_duration_seconds_bucket{procedure="/redpanda.api.console.v1alpha1.ConsoleService/ListMessages",status="ok",test="val",le="0.5"} 1
request_duration_seconds_bucket{procedure="/redpanda.api.console.v1alpha1.ConsoleService/ListMessages",status="ok",test="val",le="1"} 1
request_duration_seconds_bucket{procedure="/redpanda.api.console.v1alpha1.ConsoleService/ListMessages",status="ok",test="val",le="2.5"} 1
request_duration_seconds_bucket{procedure="/redpanda.api.console.v1alpha1.ConsoleService/ListMessages",status="ok",test="val",le="5"} 1
request_duration_seconds_bucket{procedure="/redpanda.api.console.v1alpha1.ConsoleService/ListMessages",status="ok",test="val",le="10"} 1
request_duration_seconds_bucket{procedure="/redpanda.api.console.v1alpha1.ConsoleService/ListMessages",status="ok",test="val",le="+Inf"} 1
request_duration_seconds_sum{procedure="/redpanda.api.console.v1alpha1.ConsoleService/ListMessages",status="ok",test="val"} 0.088010166
request_duration_seconds_count{procedure="/redpanda.api.console.v1alpha1.ConsoleService/ListMessages",status="ok",test="val"} 1
request_duration_seconds_bucket{procedure="/redpanda.api.dataplane.v1alpha1.ACLService/ListACLs",status="ok",test="val",le="0.005"} 1
request_duration_seconds_bucket{procedure="/redpanda.api.dataplane.v1alpha1.ACLService/ListACLs",status="ok",test="val",le="0.01"} 3
request_duration_seconds_bucket{procedure="/redpanda.api.dataplane.v1alpha1.ACLService/ListACLs",status="ok",test="val",le="0.025"} 5
request_duration_seconds_bucket{procedure="/redpanda.api.dataplane.v1alpha1.ACLService/ListACLs",status="ok",test="val",le="0.05"} 5
request_duration_seconds_bucket{procedure="/redpanda.api.dataplane.v1alpha1.ACLService/ListACLs",status="ok",test="val",le="0.1"} 5
request_duration_seconds_bucket{procedure="/redpanda.api.dataplane.v1alpha1.ACLService/ListACLs",status="ok",test="val",le="0.25"} 5
request_duration_seconds_bucket{procedure="/redpanda.api.dataplane.v1alpha1.ACLService/ListACLs",status="ok",test="val",le="0.5"} 5
request_duration_seconds_bucket{procedure="/redpanda.api.dataplane.v1alpha1.ACLService/ListACLs",status="ok",test="val",le="1"} 5
request_duration_seconds_bucket{procedure="/redpanda.api.dataplane.v1alpha1.ACLService/ListACLs",status="ok",test="val",le="2.5"} 5
request_duration_seconds_bucket{procedure="/redpanda.api.dataplane.v1alpha1.ACLService/ListACLs",status="ok",test="val",le="5"} 5
request_duration_seconds_bucket{procedure="/redpanda.api.dataplane.v1alpha1.ACLService/ListACLs",status="ok",test="val",le="10"} 5
request_duration_seconds_bucket{procedure="/redpanda.api.dataplane.v1alpha1.ACLService/ListACLs",status="ok",test="val",le="+Inf"} 5
request_duration_seconds_sum{procedure="/redpanda.api.dataplane.v1alpha1.ACLService/ListACLs",status="ok",test="val"} 0.05846533400000001
request_duration_seconds_count{procedure="/redpanda.api.dataplane.v1alpha1.ACLService/ListACLs",status="ok",test="val"} 5
request_duration_seconds_bucket{procedure="/redpanda.api.dataplane.v1alpha1.TopicService/ListTopics",status="ok",test="val",le="0.005"} 0
request_duration_seconds_bucket{procedure="/redpanda.api.dataplane.v1alpha1.TopicService/ListTopics",status="ok",test="val",le="0.01"} 1
request_duration_seconds_bucket{procedure="/redpanda.api.dataplane.v1alpha1.TopicService/ListTopics",status="ok",test="val",le="0.025"} 2
request_duration_seconds_bucket{procedure="/redpanda.api.dataplane.v1alpha1.TopicService/ListTopics",status="ok",test="val",le="0.05"} 2
request_duration_seconds_bucket{procedure="/redpanda.api.dataplane.v1alpha1.TopicService/ListTopics",status="ok",test="val",le="0.1"} 2
request_duration_seconds_bucket{procedure="/redpanda.api.dataplane.v1alpha1.TopicService/ListTopics",status="ok",test="val",le="0.25"} 2
request_duration_seconds_bucket{procedure="/redpanda.api.dataplane.v1alpha1.TopicService/ListTopics",status="ok",test="val",le="0.5"} 2
request_duration_seconds_bucket{procedure="/redpanda.api.dataplane.v1alpha1.TopicService/ListTopics",status="ok",test="val",le="1"} 2
request_duration_seconds_bucket{procedure="/redpanda.api.dataplane.v1alpha1.TopicService/ListTopics",status="ok",test="val",le="2.5"} 2
request_duration_seconds_bucket{procedure="/redpanda.api.dataplane.v1alpha1.TopicService/ListTopics",status="ok",test="val",le="5"} 2
request_duration_seconds_bucket{procedure="/redpanda.api.dataplane.v1alpha1.TopicService/ListTopics",status="ok",test="val",le="10"} 2
request_duration_seconds_bucket{procedure="/redpanda.api.dataplane.v1alpha1.TopicService/ListTopics",status="ok",test="val",le="+Inf"} 2
request_duration_seconds_sum{procedure="/redpanda.api.dataplane.v1alpha1.TopicService/ListTopics",status="ok",test="val"} 0.01675925
request_duration_seconds_count{procedure="/redpanda.api.dataplane.v1alpha1.TopicService/ListTopics",status="ok",test="val"} 2
request_duration_seconds_bucket{procedure="/redpanda.api.dataplane.v1alpha1.TransformService/ListTransforms",status="invalid_argument",test="val",le="0.005"} 1
request_duration_seconds_bucket{procedure="/redpanda.api.dataplane.v1alpha1.TransformService/ListTransforms",status="invalid_argument",test="val",le="0.01"} 1
request_duration_seconds_bucket{procedure="/redpanda.api.dataplane.v1alpha1.TransformService/ListTransforms",status="invalid_argument",test="val",le="0.025"} 1
request_duration_seconds_bucket{procedure="/redpanda.api.dataplane.v1alpha1.TransformService/ListTransforms",status="invalid_argument",test="val",le="0.05"} 2
request_duration_seconds_bucket{procedure="/redpanda.api.dataplane.v1alpha1.TransformService/ListTransforms",status="invalid_argument",test="val",le="0.1"} 2
request_duration_seconds_bucket{procedure="/redpanda.api.dataplane.v1alpha1.TransformService/ListTransforms",status="invalid_argument",test="val",le="0.25"} 2
request_duration_seconds_bucket{procedure="/redpanda.api.dataplane.v1alpha1.TransformService/ListTransforms",status="invalid_argument",test="val",le="0.5"} 2
request_duration_seconds_bucket{procedure="/redpanda.api.dataplane.v1alpha1.TransformService/ListTransforms",status="invalid_argument",test="val",le="1"} 2
request_duration_seconds_bucket{procedure="/redpanda.api.dataplane.v1alpha1.TransformService/ListTransforms",status="invalid_argument",test="val",le="2.5"} 2
request_duration_seconds_bucket{procedure="/redpanda.api.dataplane.v1alpha1.TransformService/ListTransforms",status="invalid_argument",test="val",le="5"} 2
request_duration_seconds_bucket{procedure="/redpanda.api.dataplane.v1alpha1.TransformService/ListTransforms",status="invalid_argument",test="val",le="10"} 2
request_duration_seconds_bucket{procedure="/redpanda.api.dataplane.v1alpha1.TransformService/ListTransforms",status="invalid_argument",test="val",le="+Inf"} 2
request_duration_seconds_sum{procedure="/redpanda.api.dataplane.v1alpha1.TransformService/ListTransforms",status="invalid_argument",test="val"} 0.042958541999999995
request_duration_seconds_count{procedure="/redpanda.api.dataplane.v1alpha1.TransformService/ListTransforms",status="invalid_argument",test="val"} 2
request_duration_seconds_bucket{procedure="none",status="not_found",test="val",le="0.005"} 1
request_duration_seconds_bucket{procedure="none",status="not_found",test="val",le="0.01"} 1
request_duration_seconds_bucket{procedure="none",status="not_found",test="val",le="0.025"} 1
request_duration_seconds_bucket{procedure="none",status="not_found",test="val",le="0.05"} 1
request_duration_seconds_bucket{procedure="none",status="not_found",test="val",le="0.1"} 1
request_duration_seconds_bucket{procedure="none",status="not_found",test="val",le="0.25"} 1
request_duration_seconds_bucket{procedure="none",status="not_found",test="val",le="0.5"} 1
request_duration_seconds_bucket{procedure="none",status="not_found",test="val",le="1"} 1
request_duration_seconds_bucket{procedure="none",status="not_found",test="val",le="2.5"} 1
request_duration_seconds_bucket{procedure="none",status="not_found",test="val",le="5"} 1
request_duration_seconds_bucket{procedure="none",status="not_found",test="val",le="10"} 1
request_duration_seconds_bucket{procedure="none",status="not_found",test="val",le="+Inf"} 1
request_duration_seconds_sum{procedure="none",status="not_found",test="val"} 0.0008785
request_duration_seconds_count{procedure="none",status="not_found",test="val"} 1
```