### PR TITLE
rpadmin: feature parity with rpk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ build
 # Go workspace file
 go.work
 go.work.sum
+
+.idea

--- a/rpadmin/admin.go
+++ b/rpadmin/admin.go
@@ -600,3 +600,10 @@ func ClientTimeout(t time.Duration) Opt {
 		cl.Timeout = t
 	}}
 }
+
+// MaxRetries sets the client maxRetries, overriding the default of 3.
+func MaxRetries(r int) Opt {
+	return clientOpt{func(cl *pester.Client) {
+		cl.MaxRetries = r
+	}}
+}

--- a/rpadmin/admin.go
+++ b/rpadmin/admin.go
@@ -337,7 +337,7 @@ func (a *AdminAPI) sendToLeader(ctx context.Context, method, path string, body, 
 			return err
 		} else {
 			// Got a leader ID, check if it's resolvable
-			leaderURL, err = a.brokerIDToURL(ctx, *leaderID)
+			leaderURL, err = a.BrokerIDToURL(ctx, *leaderID)
 			if err != nil && len(a.brokerIDToUrls) == 0 {
 				// Could not map any IDs: probably this is an old redpanda
 				// with no node_config endpoint.  Fall back to broadcast.
@@ -366,7 +366,8 @@ func (a *AdminAPI) sendToLeader(ctx context.Context, method, path string, body, 
 	return aLeader.sendOne(ctx, method, path, body, into, true)
 }
 
-func (a *AdminAPI) brokerIDToURL(ctx context.Context, brokerID int) (string, error) {
+// BrokerIDToURL resolves the URL of the broker with the given ID.
+func (a *AdminAPI) BrokerIDToURL(ctx context.Context, brokerID int) (string, error) {
 	if url, ok := a.getURLFromBrokerID(brokerID); ok {
 		return url, nil
 	} else { //nolint:revive // old rpk code.

--- a/rpadmin/api_debug.go
+++ b/rpadmin/api_debug.go
@@ -18,11 +18,16 @@ import (
 )
 
 const (
-	debugEndpoint          = "/v1/debug"
-	selfTestEndpoint       = debugEndpoint + "/self_test"
-	cpuProfilerEndpoint    = debugEndpoint + "/cpu_profile"
-	DiskcheckTagIdentifier = "disk"    // DiskcheckTagIdentifier is the disk identifier constant
-	NetcheckTagIdentifier  = "network" // NetcheckTagIdentifier network identifier constant
+	debugEndpoint       = "/v1/debug"
+	selfTestEndpoint    = debugEndpoint + "/self_test"
+	cpuProfilerEndpoint = debugEndpoint + "/cpu_profile"
+
+	// DiskcheckTagIdentifier is the type identifier for disk self tests.
+	DiskcheckTagIdentifier = "disk"
+	// NetcheckTagIdentifier is the type identifier for network self tests.
+	NetcheckTagIdentifier = "network"
+	// CloudcheckTagIdentifier is the type identifier for cloud self tests.
+	CloudcheckTagIdentifier = "cloud"
 )
 
 // A SelfTestNodeResult describes the results of a particular self-test run.
@@ -42,6 +47,8 @@ type SelfTestNodeResult struct {
 	TestName       string  `json:"name"`
 	TestInfo       string  `json:"info"`
 	TestType       string  `json:"test_type"`
+	StartTime      int64   `json:"start_time"`
+	EndTime        int64   `json:"end_time"`
 	Duration       uint    `json:"duration"`
 	Warning        *string `json:"warning,omitempty"`
 	Error          *string `json:"error,omitempty"`
@@ -57,6 +64,8 @@ type SelfTestNodeReport struct {
 	// If a status of idle is returned, the following `Results` variable will not
 	// be nil. In all other cases it will be nil.
 	Status string `json:"status"`
+	// One of { "idle", "net", "disk", "cloud" }
+	Stage string `json:"stage"`
 	// If value of `Status` is "idle", then this field will contain one result for
 	// each peer involved in the test. It represents the results of the last
 	// successful test run.
@@ -95,6 +104,18 @@ type NetcheckParameters struct {
 	DurationMs uint `json:"duration_ms"`
 	// Number of fibers per shard used to make network requests
 	Parallelism uint `json:"parallelism"`
+	// Filled in automatically by the \ref StartSelfTest method
+	Type string `json:"type"`
+}
+
+// CloudcheckParameters describes what parameters redpanda will use when starting the netcheck benchmark.
+type CloudcheckParameters struct {
+	// Descriptive name given to test run
+	Name string `json:"name"`
+	// Timeout duration of a network request
+	TimeoutMs uint `json:"timeout_ms"`
+	// Backoff duration of a network request
+	BackoffMs uint `json:"backoff_ms"`
 	// Filled in automatically by the \ref StartSelfTest method
 	Type string `json:"type"`
 }

--- a/rpadmin/api_partition.go
+++ b/rpadmin/api_partition.go
@@ -194,3 +194,12 @@ func (a *AdminAPI) ForceRecoverFromNode(ctx context.Context, plan []MajorityLost
 	}
 	return a.sendAny(ctx, http.MethodPost, "/v1/partitions/force_recover_from_nodes", body, nil)
 }
+
+// TransferLeadership calls attempts to transfer the leadership of the
+// namespace/topic/partition from the host of the client to the target. Make
+// sure to have a single host client when calling this endpoint. See
+// NewHostClient method.
+func (a *AdminAPI) TransferLeadership(ctx context.Context, ns, topic string, partition int, target string) error {
+	path := fmt.Sprintf("/v1/partitions/%s/%s/%d/transfer_leadership?target=%s", ns, topic, partition, target)
+	return a.sendOne(ctx, http.MethodPost, path, nil, nil, false)
+}

--- a/rpadmin/api_security.go
+++ b/rpadmin/api_security.go
@@ -57,13 +57,13 @@ type patchRoleRequest struct {
 
 // RoleMemberResponse is the response of the RoleMembers method.
 type RoleMemberResponse struct {
-	Members []RoleMember `json:"members"`
+	Members []RoleMember `json:"members" yaml:"members"`
 }
 
 // RoleDetailResponse is the response of the Role method.
 type RoleDetailResponse struct {
 	RoleName string       `json:"name" yaml:"name"`
-	Members  []RoleMember `json:"members"`
+	Members  []RoleMember `json:"members" yaml:"members"`
 }
 
 // Roles returns the roles in Redpanda, use 'prefix', 'principal', and

--- a/rpadmin/api_transform.go
+++ b/rpadmin/api_transform.go
@@ -54,13 +54,21 @@ type EnvironmentVariable struct {
 	Value string `json:"value"`
 }
 
+// Offset describes an offset relative to some timestamp or the start/end of a topic partition
+type Offset struct {
+	Format string `json:"format"`
+	Value  int64  `json:"value"`
+}
+
 // TransformMetadata is the metadata for a live running transform on a cluster.
 type TransformMetadata struct {
-	Name         string                     `json:"name"`
-	InputTopic   string                     `json:"input_topic"`
-	OutputTopics []string                   `json:"output_topics"`
-	Status       []PartitionTransformStatus `json:"status,omitempty"`
-	Environment  []EnvironmentVariable      `json:"environment,omitempty"`
+	Name            string                     `json:"name"`
+	InputTopic      string                     `json:"input_topic"`
+	OutputTopics    []string                   `json:"output_topics"`
+	Status          []PartitionTransformStatus `json:"status,omitempty"`
+	Environment     []EnvironmentVariable      `json:"environment,omitempty"`
+	CompressionMode string                     `json:"compression,omitempty"`
+	FromOffset      *Offset                    `json:"offset,omitempty"`
 }
 
 // ListWasmTransforms lists the transforms that are running on a cluster.
@@ -68,4 +76,47 @@ func (a *AdminAPI) ListWasmTransforms(ctx context.Context) ([]TransformMetadata,
 	resp := []TransformMetadata{}
 	err := a.sendAny(ctx, http.MethodGet, baseTransformEndpoint, nil, &resp)
 	return resp, err
+}
+
+type patchMetadataRequest struct {
+	IsPaused        *bool                  `json:"is_paused,omitempty"`
+	Environment     *[]EnvironmentVariable `json:"env,omitempty"`
+	CompressionMode *string                `json:"compression,omitempty"`
+}
+
+func metaEndpoint(transformName string) string {
+	return baseTransformEndpoint + url.PathEscape(transformName) + "/meta"
+}
+
+// PauseTransform patches transform metadata to set paused = true, with no effect on the transform's env
+func (a *AdminAPI) PauseTransform(ctx context.Context, transformName string) error {
+	paused := true
+	body := patchMetadataRequest{
+		IsPaused:        &paused,
+		Environment:     nil,
+		CompressionMode: nil,
+	}
+	return a.sendAny(ctx, http.MethodPut, metaEndpoint(transformName), body, nil)
+}
+
+// ResumeTransform patches transform metadata to set paused = false, with no effect on the transform's env
+func (a *AdminAPI) ResumeTransform(ctx context.Context, transformName string) error {
+	paused := false
+	body := patchMetadataRequest{
+		IsPaused:        &paused,
+		Environment:     nil,
+		CompressionMode: nil,
+	}
+	return a.sendAny(ctx, http.MethodPut, metaEndpoint(transformName), body, nil)
+}
+
+// SetTransformCompressionMode patches transform metadata to set the transform compression mode
+func (a *AdminAPI) SetTransformCompressionMode(ctx context.Context, transformName string, compressionMode string) error {
+	body := patchMetadataRequest{
+		IsPaused:        nil,
+		Environment:     nil,
+		CompressionMode: &compressionMode,
+	}
+
+	return a.sendAny(ctx, http.MethodPut, metaEndpoint(transformName), body, nil)
 }


### PR DESCRIPTION
We are working to migrate rpk finally to common-go, since the repo was created we've added a few endpoints that we need once we migrate. This PR includes a commit-by-commit history of all the endpoints that are being added.

For more information on them, you can also check all the changes here https://github.com/redpanda-data/redpanda/commits/dev/src/go/rpk/pkg/adminapi since `5080bd3`