### PR TITLE
rpadmin: change SetLicense input from any to io.Reader

### DIFF
--- a/rpadmin/api_features.go
+++ b/rpadmin/api_features.go
@@ -11,6 +11,7 @@ package rpadmin
 
 import (
 	"context"
+	"io"
 	"net/http"
 )
 
@@ -70,7 +71,7 @@ func (a *AdminAPI) GetLicenseInfo(ctx context.Context) (License, error) {
 	return license, a.sendToLeader(ctx, http.MethodGet, "/v1/features/license", nil, &license)
 }
 
-// SetLicense sets the license.
-func (a *AdminAPI) SetLicense(ctx context.Context, license any) error {
+// SetLicense sets the base 64 encoding of the license.
+func (a *AdminAPI) SetLicense(ctx context.Context, license io.Reader) error {
 	return a.sendToLeader(ctx, http.MethodPut, "/v1/features/license", license, nil)
 }


### PR DESCRIPTION
It was unclear to the caller what to pass to the
SetLicense method. It was any because it was a
carryover from rpk, but we should use stricter
typing in our methods.

WARNING: This is a breaking change of the API, however, the only known caller is rpk, which already passes an `io.Reader` https://github.com/redpanda-data/redpanda/blob/dev/src/go/rpk/pkg/cli/cluster/license/set.go#L51.