### PR TITLE
rpadmin: support namespaced and inbound topic in migration state

### DIFF
--- a/rpadmin/api_migration.go
+++ b/rpadmin/api_migration.go
@@ -124,8 +124,13 @@ type MigrationState struct {
 
 // Migration represents a migration
 type Migration struct {
-	MigrationType string            `json:"migration_type"`
-	Topics        []NamespacedTopic `json:"topics"`
+	// MigrationType is either 'outbound' or 'inbound'.
+	MigrationType string `json:"migration_type"`
+
+	// Topics is a list of migrated topics. It is reported in two different fashions, depending on the MigrationType.
+	// For outbound migrations topics of type NamespacedTopic are reported.
+	// For inbound migrations the topics will only be reported with type InboundTopic.
+	Topics []NamespacedOrInboundTopic `json:"topics"`
 }
 
 // AddMigrationResponse is the response from adding a migration

--- a/rpadmin/api_migration_test.go
+++ b/rpadmin/api_migration_test.go
@@ -367,7 +367,14 @@ func TestGetMigration(t *testing.T) {
 				State: "prepared",
 				Migration: Migration{
 					MigrationType: "inbound",
-					Topics:        []NamespacedTopic{{Topic: "test-topic", Namespace: string2Pointer("test-ns")}},
+					Topics: []NamespacedOrInboundTopic{
+						{
+							InboundTopic: InboundTopic{
+								SourceTopicReference: NamespacedTopic{Topic: "test-topic", Namespace: string2Pointer("test-ns")},
+								Alias:                nil,
+							},
+						},
+					},
 				},
 			},
 			serverStatus: http.StatusOK,
@@ -424,7 +431,14 @@ func TestListMigrations(t *testing.T) {
 					State: "prepared",
 					Migration: Migration{
 						MigrationType: "inbound",
-						Topics:        []NamespacedTopic{{Topic: "test-topic-1", Namespace: string2Pointer("test-ns")}},
+						Topics: []NamespacedOrInboundTopic{
+							{
+								NamespacedTopic: NamespacedTopic{
+									Topic:     "test-topic-1",
+									Namespace: string2Pointer("test-ns"),
+								},
+							},
+						},
 					},
 				},
 				{
@@ -432,7 +446,14 @@ func TestListMigrations(t *testing.T) {
 					State: "executed",
 					Migration: Migration{
 						MigrationType: "outbound",
-						Topics:        []NamespacedTopic{{Topic: "test-topic-2", Namespace: string2Pointer("test-ns")}},
+						Topics: []NamespacedOrInboundTopic{
+							{
+								NamespacedTopic: NamespacedTopic{
+									Topic:     "test-topic-2",
+									Namespace: string2Pointer("test-ns"),
+								},
+							},
+						},
 					},
 				},
 			},

--- a/rpadmin/api_mount.go
+++ b/rpadmin/api_mount.go
@@ -23,6 +23,12 @@ type InboundTopic struct {
 	Alias                *NamespacedTopic `json:"alias,omitempty"`
 }
 
+// NamespacedOrInboundTopic is a composite struct of NamespacedTopic and InboundTopic.
+type NamespacedOrInboundTopic struct {
+	NamespacedTopic
+	InboundTopic
+}
+
 // MountConfiguration represents the configuration for mounting topics
 type MountConfiguration struct {
 	Topics []InboundTopic `json:"topics"`


### PR DESCRIPTION
The returned migration may be an inbound or outbound migration. Depending on the type the schema is different as per: https://github.com/redpanda-data/redpanda/blob/40e0dcab0303ccc8a38cbb30b327723aa9d3964d/src/v/redpanda/admin/api-doc/migration.json#L17-L23

This change reflects that behaviour.