### PR TITLE
fix: wrong return from get and list for migration

### DIFF
--- a/rpadmin/api_migration_test.go
+++ b/rpadmin/api_migration_test.go
@@ -355,19 +355,42 @@ func TestGetMigration(t *testing.T) {
 	tests := []struct {
 		name           string
 		migrationID    int
-		serverResponse MigrationState
+		serverResponse *MigrationState
 		serverStatus   int
 		expectError    bool
 	}{
 		{
-			name:        "successful get migration",
+			name:        "successful get outbound migration",
 			migrationID: 123,
-			serverResponse: MigrationState{
+			serverResponse: &MigrationState{
 				ID:    123,
 				State: "prepared",
-				Migration: Migration{
+				Migration: &OutboundMigration{
+					MigrationType:  "outbound",
+					Topics:         []NamespacedTopic{{Topic: "test-topic", Namespace: string2Pointer("test-ns1")}},
+					ConsumerGroups: nil,
+					AutoAdvance:    true,
+				},
+			},
+			serverStatus: http.StatusOK,
+			expectError:  false,
+		},
+		{
+			name:        "successful get inbound migration",
+			migrationID: 123,
+			serverResponse: &MigrationState{
+				ID:    123,
+				State: "prepared",
+				Migration: &InboundMigration{
 					MigrationType: "inbound",
-					Topics:        []NamespacedTopic{{Topic: "test-topic", Namespace: string2Pointer("test-ns")}},
+					Topics: []InboundTopic{
+						{
+							SourceTopicReference: NamespacedTopic{Topic: "topic", Namespace: string2Pointer("test-ns1")},
+							Alias:                nil,
+						},
+					},
+					ConsumerGroups: nil,
+					AutoAdvance:    true,
 				},
 			},
 			serverStatus: http.StatusOK,
@@ -422,15 +445,22 @@ func TestListMigrations(t *testing.T) {
 				{
 					ID:    123,
 					State: "prepared",
-					Migration: Migration{
+					Migration: &InboundMigration{
 						MigrationType: "inbound",
-						Topics:        []NamespacedTopic{{Topic: "test-topic-1", Namespace: string2Pointer("test-ns")}},
+						Topics: []InboundTopic{
+							{
+								SourceTopicReference: NamespacedTopic{Topic: "topic", Namespace: string2Pointer("test-ns")},
+								Alias:                nil,
+							},
+						},
+						ConsumerGroups: nil,
+						AutoAdvance:    true,
 					},
 				},
 				{
 					ID:    456,
 					State: "executed",
-					Migration: Migration{
+					Migration: &OutboundMigration{
 						MigrationType: "outbound",
 						Topics:        []NamespacedTopic{{Topic: "test-topic-2", Namespace: string2Pointer("test-ns")}},
 					},


### PR DESCRIPTION
After a change in the API, GetMigration and ListMigration were improperly returning values that only supported outbound migrations.

The tricky bit here was that MigrationState could hold either an Inbound or an Outbound in the Migration field.

To deal with this I used a json.RawMessage to hold the field's contents temporarily. Alternative approaches resulted in a field full of horrifying nested maps no developer was ever meant to see.

Once we have the RawMessage we can properly unmarshal it and return things. The end user should have an easier time as they can call GetMigrationType() and then type assert to the correct value.