### PR TITLE
Close leaked response bodies

### DIFF
--- a/rpadmin/admin.go
+++ b/rpadmin/admin.go
@@ -69,6 +69,10 @@ type (
 	NopAuth struct{}
 )
 
+// responseWrapper functions as a testing mechanism for ensuring
+// that we actually close all of our network connections
+var responseWrapper = func(r *http.Response) *http.Response { return r }
+
 func (a *BasicAuth) apply(req *http.Request) {
 	req.SetBasicAuth(a.Username, a.Password)
 }
@@ -648,6 +652,11 @@ func (a *AdminAPI) sendAndReceive(
 		res, err = a.retryClient.Do(req)
 	} else {
 		res, err = a.oneshotClient.Do(req)
+	}
+
+	if res != nil {
+		// this is mainly used to ensure we're cleaning up all of our responses
+		res = responseWrapper(res)
 	}
 
 	if err != nil {

--- a/rpadmin/api_debug.go
+++ b/rpadmin/api_debug.go
@@ -441,6 +441,7 @@ func (a *AdminAPI) DeleteDebugBundleFile(ctx context.Context, filename string) e
 }
 
 // DownloadDebugBundleFile gets the specific debug bundle file on the specified broker node.
+// The caller must call close on the response returned as it does not yet have its body read.
 func (a *AdminAPI) DownloadDebugBundleFile(ctx context.Context, filename string) (*http.Response, error) {
 	if len(a.urls) != 1 {
 		return nil, fmt.Errorf("unable to issue a single-admin-endpoint request to %d admin endpoints", len(a.urls))


### PR DESCRIPTION
This ensures that we close all response bodies (or documents when they should be closed, but aren't). Working on some tests/validations, but throwing this up here for some eyes.