### PR TITLE
Add cleanup routines for underlying http transport

### DIFF
--- a/rpadmin/admin_test.go
+++ b/rpadmin/admin_test.go
@@ -391,7 +391,7 @@ func TestIdleConnectionClosure(t *testing.T) {
 			case strings.HasPrefix(r.URL.Path, "/v1/node_config"):
 				w.Write([]byte(fmt.Sprintf(`{"node_id": %d}`, id))) //nolint:gocritic // original rpk code
 			case strings.HasPrefix(r.URL.Path, "/v1/partitions/redpanda/controller/0"):
-				w.Write([]byte(`{"leader_id": 0}`)) //nolint:gocritic // original rpk code
+				w.Write([]byte(`{"leader_id": 0}`))
 			}
 		}))
 
@@ -425,7 +425,7 @@ func TestIdleConnectionClosure(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		adminClient.Close()
+		// adminClient.Close()
 	}
 
 	mutex.RLock()

--- a/rpadmin/admin_test.go
+++ b/rpadmin/admin_test.go
@@ -425,7 +425,7 @@ func TestIdleConnectionClosure(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		// adminClient.Close()
+		adminClient.Close()
 	}
 
 	mutex.RLock()


### PR DESCRIPTION
This PR does a couple of things:

1. It limits the amount of connections we actually allow the undelrying `http.Transport` to initialize in the rpadmin client and sets some sane defaults based for idle connection timeouts based off of `http.DefaultTransport`
2. It introduces a `Close` method that flushes all idle connections in the connection pool. This allows us to manually close all pooled connections when a client is no longer needed.