### PR TITLE
Add local partition summary support and fix dialer usage when leveraging ForBroker and the like

### DIFF
--- a/rpadmin/admin.go
+++ b/rpadmin/admin.go
@@ -96,6 +96,7 @@ type AdminAPI struct {
 	urls                []string
 	brokerIDToUrlsMutex sync.Mutex
 	brokerIDToUrls      map[int]string
+	dialer              DialContextFunc
 	transport           *http.Transport
 	retryClient         *pester.Client
 	oneshotClient       *http.Client
@@ -192,6 +193,7 @@ func newAdminAPI(urls []string, auth Auth, tlsConfig *tls.Config, dialer DialCon
 		tlsConfig:      tlsConfig,
 		brokerIDToUrls: make(map[int]string),
 		forCloud:       forCloud,
+		dialer:         dialer,
 	}
 
 	if tlsConfig != nil {
@@ -271,7 +273,7 @@ func (a *AdminAPI) ForHost(url string) (*AdminAPI, error) {
 }
 
 func (a *AdminAPI) newAdminForSingleHost(host string) (*AdminAPI, error) {
-	return newAdminAPI([]string{host}, a.auth, a.tlsConfig, nil, a.forCloud)
+	return newAdminAPI([]string{host}, a.auth, a.tlsConfig, a.dialer, a.forCloud)
 }
 
 func (a *AdminAPI) urlsWithPath(path string) []string {

--- a/rpadmin/api_partition.go
+++ b/rpadmin/api_partition.go
@@ -60,6 +60,13 @@ type Partition struct {
 	Replicas    []Replica `json:"replicas"`
 }
 
+// LocalPartitionSummary is the information returned from the Redpanda admin local partition summary endpoint.
+type LocalPartitionSummary struct {
+	Count           int `json:"count"`
+	Leaderless      int `json:"leaderless"`
+	UnderReplicated int `json:"under_replicated"`
+}
+
 // Operation represents an operation.
 type Operation struct {
 	Core        int    `json:"core"`
@@ -104,6 +111,13 @@ type MajorityLostPartitions struct {
 	TopicRevision int       `json:"topic_revision" yaml:"topic_revision"`
 	Replicas      []Replica `json:"replicas,omitempty" yaml:"replicas,omitempty"`
 	DeadNodes     []int     `json:"dead_nodes,omitempty" yaml:"dead_nodes,omitempty"`
+}
+
+// GetLocalPartitionsSummary returns summary partition information for a broker. To be used deterministically,
+// the admin client must be configured to use only a single broker.
+func (a *AdminAPI) GetLocalPartitionsSummary(ctx context.Context) (LocalPartitionSummary, error) {
+	var lps LocalPartitionSummary
+	return lps, a.sendOne(ctx, http.MethodGet, "/v1/partitions/local_summary", nil, &lps, false)
 }
 
 // GetPartition returns detailed partition information.


### PR DESCRIPTION
This adds support for the [`/v1/partitions/local_summary`](https://docs.redpanda.com/api/admin-api/#get-/v1/partitions/local_summary) endpoint.

Additionally, it fixes and issue with attempting to use the newly introduced mechanism to create a scoped client leveraging `ForBroker`. Specifically, when attempting to map a broker id to URL, the code [initializes](https://github.com/redpanda-data/common-go/blob/05ac5889aee7acab24333d9cdbba23f8f25285a1/rpadmin/admin.go#L577) a "single host" client. When passing a custom dialer to the parent client, this dialer was no longer used in the subclients, which, in the Kubernetes test case where we use a dialer that is actually opening up port-forwarded connections, means that we immediately fail to resolve the Kubernetes DNS host we're attempting to point at. This is fixed by just holding a reference to the dialer in the parent client and passing the dialer along when we initialize a new client using the parent client.