### PR TITLE
rpadmin: Use json.Number to prevent precision loss

### DIFF
--- a/rpadmin/api_config.go
+++ b/rpadmin/api_config.go
@@ -10,6 +10,7 @@
 package rpadmin
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -36,7 +37,9 @@ func (a *AdminAPI) Config(ctx context.Context, includeDefaults bool) (Config, er
 		return nil, err
 	}
 	var unmarshaled Config
-	if err := json.Unmarshal(rawResp, &unmarshaled); err != nil {
+	decoder := json.NewDecoder(bytes.NewReader(rawResp))
+	decoder.UseNumber()
+	if err := decoder.Decode(&unmarshaled); err != nil {
 		return nil, fmt.Errorf("unable to decode response body: %w", err)
 	}
 	return unmarshaled, nil
@@ -54,7 +57,9 @@ func (a *AdminAPI) SingleKeyConfig(ctx context.Context, key string) (Config, err
 		return nil, err
 	}
 	var unmarshaled Config
-	if err := json.Unmarshal(rawResp, &unmarshaled); err != nil {
+	decoder := json.NewDecoder(bytes.NewReader(rawResp))
+	decoder.UseNumber()
+	if err := decoder.Decode(&unmarshaled); err != nil {
 		return nil, fmt.Errorf("unable to decode response body: %w", err)
 	}
 	return unmarshaled, nil

--- a/rpadmin/api_config_test.go
+++ b/rpadmin/api_config_test.go
@@ -1,0 +1,49 @@
+package rpadmin
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigHandlesUint64AsString(t *testing.T) {
+	rawJSON := []byte(`{"big_number": 18446744073709551615}`) // Max uint64 value
+	respHandler := func() http.HandlerFunc {
+		return func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write(rawJSON)
+		}
+	}
+	ts := httptest.NewServer(respHandler())
+	defer ts.Close()
+
+	cl, err := NewAdminAPI([]string{ts.URL}, new(NopAuth), nil)
+	require.NoError(t, err)
+
+	config, err := cl.Config(context.Background(), true)
+	require.NoError(t, err)
+
+	// Verify that the number is retained as a json.Number.
+	bigNumber, ok := config["big_number"].(json.Number)
+	if !ok {
+		t.Fatalf("Expected json.Number, got %T", config["big_number"])
+	}
+
+	// Ensure that the value is correct as a string.
+	expected := "18446744073709551615"
+	require.Equal(t, expected, bigNumber.String(), "Expected %s, got %s", expected, bigNumber.String())
+
+	// This could cause precision loss, but it will not fail.
+	if _, err := bigNumber.Float64(); err != nil {
+		t.Errorf("Unexpected error converting to float64: %v", err)
+	}
+
+	// Conversion to int64 fails (since it's out of int64 range)
+	if _, err := bigNumber.Int64(); err == nil {
+		t.Errorf("Expected error converting to int64, but got none")
+	}
+}


### PR DESCRIPTION
Switching from json.Unmarshal to json.NewDecoder
with UseNumber to handle large numbers correctly.

json.Unmarshal converts numbers to float64 by
default, which can lead to precision loss when
dealing with large integers. Using json.Decoder
with UseNumber ensures numbers are preserved as
json.Number, allowing proper handling without
unintended rounding errors.

See: https://github.com/redpanda-data/redpanda/issues/16723