### PR TITLE
chore: update golangci lint to 1.64

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -15,7 +15,7 @@ on:
       - './github/workflows/golangci-lint.yaml'
 
 env:
-  GOLANGCI_LINT_VERSION: v1.61
+  GOLANGCI_LINT_VERSION: v1.64
 
 permissions:
   contents: read


### PR DESCRIPTION
The current version is incompatible with Go 1.24