### PR TITLE
rpadmin: fix linter issues in `rpadmin`

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -7,12 +7,12 @@ on:
     paths:
       - '**.go'
       - '.golangci.yaml'
-      - './github/workflows/golangci-lint.yaml'
+      - './.github/workflows/golangci-lint.yaml'
   pull_request:
     paths:
       - '**.go'
       - '.golangci.yaml'
-      - './github/workflows/golangci-lint.yaml'
+      - './.github/workflows/golangci-lint.yaml'
 
 env:
   GOLANGCI_LINT_VERSION: v1.64

--- a/rpadmin/api_broker.go
+++ b/rpadmin/api_broker.go
@@ -91,7 +91,7 @@ type BrokerUuids struct {
 func (a *AdminAPI) Brokers(ctx context.Context) ([]Broker, error) {
 	var bs []Broker
 	defer func() {
-		sort.Slice(bs, func(i, j int) bool { return bs[i].NodeID < bs[j].NodeID }) //nolint:revive // return inside this deferred function is for the sort's less function
+		sort.Slice(bs, func(i, j int) bool { return bs[i].NodeID < bs[j].NodeID })
 	}()
 	return bs, a.sendAny(ctx, http.MethodGet, brokersEndpoint, nil, &bs)
 }

--- a/rpadmin/api_features.go
+++ b/rpadmin/api_features.go
@@ -19,11 +19,16 @@ import (
 type FeatureState string
 
 const (
-	FeatureStateActive      FeatureState = "active"      // FeatureStateActive is the active state.
-	FeatureStatePreparing   FeatureState = "preparing"   // FeatureStatePreparing is the preparing state.
-	FeatureStateAvailable   FeatureState = "available"   // FeatureStateAvailable is the available state.
-	FeatureStateUnavailable FeatureState = "unavailable" // FeatureStateUnavailable is the unavailable state.
-	FeatureStateDisabled    FeatureState = "disabled"    // FeatureStateDisabled is the disabled state.
+	// FeatureStateActive is the active state.
+	FeatureStateActive FeatureState = "active"
+	// FeatureStatePreparing is the preparing state.
+	FeatureStatePreparing FeatureState = "preparing"
+	// FeatureStateAvailable is the available state.
+	FeatureStateAvailable FeatureState = "available"
+	// FeatureStateUnavailable is the unavailable state.
+	FeatureStateUnavailable FeatureState = "unavailable"
+	// FeatureStateDisabled is the disabled state.
+	FeatureStateDisabled FeatureState = "disabled"
 )
 
 // Feature contains information on the state of a feature.

--- a/rpadmin/api_migration.go
+++ b/rpadmin/api_migration.go
@@ -11,6 +11,7 @@ package rpadmin
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"reflect"
@@ -65,7 +66,7 @@ type InboundMigrationState struct {
 func (a *AdminAPI) addMigration(ctx context.Context, migration any) (AddMigrationResponse, error) {
 	migrationType := reflect.TypeOf(migration)
 	if migrationType != reflect.TypeOf(InboundMigration{}) && migrationType != reflect.TypeOf(OutboundMigration{}) {
-		return AddMigrationResponse{}, fmt.Errorf("invalid migration type: must be either InboundMigration or OutboundMigration")
+		return AddMigrationResponse{}, errors.New("invalid migration type: must be either InboundMigration or OutboundMigration")
 	}
 
 	var response AddMigrationResponse


### PR DESCRIPTION
And also fixes a typo in the `.github` directory path that prevented the CI from picking up changes in the dir to trigger the linter job.