### PR TITLE
Fix protobuf extension tag conflict

### DIFF
--- a/proto/redpanda/api/common/v1/options.proto
+++ b/proto/redpanda/api/common/v1/options.proto
@@ -8,5 +8,5 @@ option go_package = "buf.build/gen/go/redpandadata/common/protocolbuffers/go/red
 
 // Option used by protoc-gen-permissions
 extend google.protobuf.MethodOptions {
-  repeated string required_permission = 15350;
+  repeated string required_permission = 15351;
 }


### PR DESCRIPTION
## Summary
- Fixed protobuf extension tag conflict between v1 and v1alpha1 options.proto files
- Changed extension tag from 15350 to 15351 in v1/options.proto to resolve buf lint error