### PR TITLE
rpsr: add rpsr package, Redpanda Schema registry

### DIFF
--- a/rpsr/builder.go
+++ b/rpsr/builder.go
@@ -1,0 +1,260 @@
+package rpsr
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// ACLBuilder helps construct sets of ACL rules for Redpanda's Schema Registry.
+type ACLBuilder struct {
+	allowPrincipal []string
+	denyPrincipal  []string
+
+	allowHost []string
+	denyHost  []string
+
+	allRegistry bool
+	subjects    []string
+
+	operations []Operation
+	pattern    PatternType
+}
+
+// NewACLBuilder initializes a new ACLBuilder.
+func NewACLBuilder() *ACLBuilder {
+	return new(ACLBuilder)
+}
+
+// PrefixUserExcept prefixes all unqualified principals with "User:", unless they
+// start with any of the specified exception prefixes (e.g., "RedpandaRole:").
+func (b *ACLBuilder) PrefixUserExcept(except ...string) {
+	replace := func(principal string) string {
+		if !strings.HasPrefix(principal, "User:") {
+			for _, e := range except {
+				if strings.HasPrefix(principal, e) {
+					return principal
+				}
+			}
+			return "User:" + principal
+		}
+		return principal
+	}
+	for i, p := range b.allowPrincipal {
+		b.allowPrincipal[i] = replace(p)
+	}
+	for i, p := range b.denyPrincipal {
+		b.denyPrincipal[i] = replace(p)
+	}
+}
+
+// AllowPrincipals sets principals to be granted permissions.
+func (b *ACLBuilder) AllowPrincipals(principals ...string) *ACLBuilder {
+	b.allowPrincipal = principals
+	return b
+}
+
+// AllowPrincipalsOrAny sets allowed principals or defaults to "*" if empty.
+func (b *ACLBuilder) AllowPrincipalsOrAny(principals ...string) *ACLBuilder {
+	b.allowPrincipal = principals
+	if len(principals) == 0 {
+		b.allowPrincipal = []string{"*"}
+	}
+	return b
+}
+
+// DenyPrincipals sets principals to be explicitly denied.
+func (b *ACLBuilder) DenyPrincipals(principals ...string) *ACLBuilder {
+	b.denyPrincipal = principals
+	return b
+}
+
+// DenyPrincipalsOrAny sets denied principals or defaults to "*" if empty.
+func (b *ACLBuilder) DenyPrincipalsOrAny(principals ...string) *ACLBuilder {
+	b.denyPrincipal = principals
+	if len(principals) == 0 {
+		b.denyPrincipal = []string{"*"}
+	}
+	return b
+}
+
+// AllowHosts sets hosts for which allow rules apply.
+func (b *ACLBuilder) AllowHosts(hosts ...string) *ACLBuilder {
+	b.allowHost = hosts
+	return b
+}
+
+// AllowHostsOrAny sets allowed hosts or defaults to "*" if empty.
+func (b *ACLBuilder) AllowHostsOrAny(hosts ...string) *ACLBuilder {
+	b.allowHost = hosts
+	if len(hosts) == 0 {
+		b.allowHost = []string{"*"}
+	}
+	return b
+}
+
+// DenyHosts sets hosts for which deny rules apply.
+func (b *ACLBuilder) DenyHosts(hosts ...string) *ACLBuilder {
+	b.denyHost = hosts
+	return b
+}
+
+// DenyHostsOrAny sets denied hosts or defaults to "*" if empty.
+func (b *ACLBuilder) DenyHostsOrAny(hosts ...string) *ACLBuilder {
+	b.denyHost = hosts
+	if len(hosts) == 0 {
+		b.denyHost = []string{"*"}
+	}
+	return b
+}
+
+// Registry indicates that ACLs should be created for the registry itself.
+// Registry ACLs do not include a resource name.
+func (b *ACLBuilder) Registry() *ACLBuilder {
+	b.allRegistry = true
+	return b
+}
+
+// Subjects sets the list of schema subjects to apply ACLs to.
+func (b *ACLBuilder) Subjects(subjects ...string) *ACLBuilder {
+	b.subjects = subjects
+	return b
+}
+
+// SubjectsOrAny sets subjects or defaults to "*" if none are provided.
+func (b *ACLBuilder) SubjectsOrAny(subjects ...string) *ACLBuilder {
+	b.subjects = subjects
+	if len(subjects) == 0 {
+		b.subjects = []string{"*"}
+	}
+	return b
+}
+
+// Operations sets the operations the ACLs should allow or deny.
+func (b *ACLBuilder) Operations(operations ...Operation) *ACLBuilder {
+	b.operations = operations
+	return b
+}
+
+// OperationsOrAll sets the operations or defaults to ALL if none are specified.
+func (b *ACLBuilder) OperationsOrAll(operations ...Operation) *ACLBuilder {
+	b.operations = operations
+	if len(operations) == 0 {
+		b.operations = []Operation{OperationAll}
+	}
+	return b
+}
+
+// Pattern sets the pattern type (LITERAL or PREFIX) for matching subject names.
+func (b *ACLBuilder) Pattern(pattern PatternType) *ACLBuilder {
+	b.pattern = pattern
+	return b
+}
+
+// PatternOrLiteral sets the pattern type or defaults to LITERAL if not
+// specified.
+func (b *ACLBuilder) PatternOrLiteral(pattern PatternType) *ACLBuilder {
+	b.pattern = pattern
+	if pattern == "" {
+		b.pattern = PatternTypeLiteral
+	}
+	return b
+}
+
+// Validate ensures the builder is properly configured before building ACLs.
+func (b *ACLBuilder) Validate() error {
+	if len(b.operations) == 0 {
+		return errors.New("invalid empty operations: at least one operation is required to create an ACL")
+	}
+	if b.pattern == "" {
+		return errors.New("invalid empty pattern type")
+	}
+	if len(b.allowHost) != 0 && len(b.allowPrincipal) == 0 {
+		return errors.New("invalid allow hosts with no allowed principals")
+	}
+	if len(b.denyHost) != 0 && len(b.denyPrincipal) == 0 {
+		return errors.New("invalid deny hosts with no denied principals")
+	}
+	if len(b.allowPrincipal) != 0 && len(b.allowHost) == 0 {
+		return errors.New("invalid allow principal with no allowed hosts")
+	}
+	if len(b.denyPrincipal) != 0 && len(b.denyHost) == 0 {
+		return errors.New("invalid deny principals with no denied hosts")
+	}
+	for _, p := range append(b.allowPrincipal, b.denyPrincipal...) {
+		if p != "*" && !(strings.HasPrefix(p, "User:") || strings.HasPrefix(p, "RedpandaRole:")) {
+			return fmt.Errorf("invalid principal %v: must start with 'User:' or 'RedpandaRole:'", p)
+		}
+	}
+	return nil
+}
+
+// ValidateAndBuild validates the builder's configuration and constructs ACLs.
+func (b *ACLBuilder) ValidateAndBuild() ([]ACL, error) {
+	err := b.Validate()
+	if err != nil {
+		return nil, err
+	}
+	return b.Build(), nil
+}
+
+// Build constructs a unique list of ACL entries based on the builder's
+// configuration.
+//
+// This method assumes the configuration has already been validated using
+// Validate() to prevent empty ACLs from being built. It performs a
+// combinatorial expansion of principals, hosts, operations, and resource types
+// into individual ACL entries, eliminating duplicates.
+func (b *ACLBuilder) Build() []ACL {
+	var acls []ACL
+	seen := make(map[string]struct{})
+
+	add := func(principal string, host string, permission Permission, resourceType ResourceType, resource string) {
+		for _, op := range b.operations {
+			acl := ACL{
+				Principal:    principal,
+				Resource:     resource,
+				ResourceType: resourceType,
+				Host:         host,
+				Operation:    op,
+				Permission:   permission,
+			}
+			if resourceType != ResourceTypeRegistry {
+				acl.PatternType = b.pattern
+			}
+			key := aclKey(acl)
+			if _, ok := seen[key]; !ok {
+				seen[key] = struct{}{}
+				acls = append(acls, acl)
+			}
+		}
+	}
+
+	if b.allRegistry {
+		for _, p := range b.allowPrincipal {
+			for _, h := range b.allowHost {
+				add(p, h, PermissionAllow, ResourceTypeRegistry, "") // Registry ACLs do not have a resource name.
+			}
+		}
+		for _, p := range b.denyPrincipal {
+			for _, h := range b.denyHost {
+				add(p, h, PermissionDeny, ResourceTypeRegistry, "")
+			}
+		}
+	}
+
+	for _, s := range b.subjects {
+		for _, p := range b.allowPrincipal {
+			for _, h := range b.allowHost {
+				add(p, h, PermissionAllow, ResourceTypeSubject, s)
+			}
+		}
+		for _, p := range b.denyPrincipal {
+			for _, h := range b.denyHost {
+				add(p, h, PermissionDeny, ResourceTypeSubject, s)
+			}
+		}
+	}
+
+	return acls
+}

--- a/rpsr/builder_test.go
+++ b/rpsr/builder_test.go
@@ -1,0 +1,198 @@
+package rpsr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestACLBuilder_Validate(t *testing.T) {
+	tests := []struct {
+		name        string
+		builder     *ACLBuilder
+		expectError bool
+	}{
+		{
+			name: "valid builder with all fields - defaults",
+			// builder using all defaults.
+			builder: NewACLBuilder().
+				AllowPrincipalsOrAny().
+				DenyPrincipalsOrAny().
+				AllowHostsOrAny().
+				DenyHostsOrAny().
+				OperationsOrAll().
+				PatternOrLiteral(""),
+			expectError: false,
+		},
+		{
+			name: "valid builder with all fields",
+			builder: NewACLBuilder().
+				AllowPrincipals("User:foo", "RedpandaRole:admin").
+				AllowHosts("host-1").
+				Operations(OperationRead, OperationWrite).
+				Pattern(PatternTypePrefix),
+			expectError: false,
+		},
+		{
+			name: "missing allow principals",
+			// builder using all defaults.
+			builder: NewACLBuilder().
+				AllowHostsOrAny().
+				OperationsOrAll().
+				PatternOrLiteral(""),
+			expectError: true,
+		},
+		{
+			name: "missing allow principals",
+			// builder using all defaults.
+			builder: NewACLBuilder().
+				AllowHostsOrAny().
+				OperationsOrAll().
+				PatternOrLiteral(""),
+			expectError: true,
+		},
+		{
+			name: "missing allow Hosts",
+			// builder using all defaults.
+			builder: NewACLBuilder().
+				AllowPrincipals("User:foo").
+				OperationsOrAll().
+				PatternOrLiteral(""),
+			expectError: true,
+		},
+		{
+			name: "missing operations",
+			builder: NewACLBuilder().
+				AllowPrincipals("User:alice").
+				AllowHosts("*").
+				Pattern(PatternTypeLiteral),
+			expectError: true,
+		},
+		{
+			name: "missing pattern",
+			builder: NewACLBuilder().
+				AllowPrincipals("User:alice").
+				AllowHosts("*").
+				Operations(OperationRead),
+			expectError: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.builder.Validate()
+			if tt.expectError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestACLBuilder_Build(t *testing.T) {
+	tests := []struct {
+		name    string
+		builder func() *ACLBuilder
+		exp     []ACL
+	}{
+		{
+			name: "Valid builder with all fields - defaults",
+			builder: func() *ACLBuilder {
+				b := NewACLBuilder().
+					AllowPrincipals("*").
+					DenyPrincipalsOrAny().
+					SubjectsOrAny().
+					Registry().
+					AllowHostsOrAny().
+					DenyHostsOrAny().
+					OperationsOrAll().
+					PatternOrLiteral("")
+				b.PrefixUserExcept("RedpandaRole:admin")
+				return b
+			},
+			exp: []ACL{
+				{Principal: "User:*", Host: "*", Operation: OperationAll, PatternType: PatternTypeLiteral, Permission: PermissionAllow, Resource: "*", ResourceType: ResourceTypeSubject},
+				{Principal: "User:*", Host: "*", Operation: OperationAll, PatternType: PatternTypeLiteral, Permission: PermissionDeny, Resource: "*", ResourceType: ResourceTypeSubject},
+				{Principal: "User:*", Host: "*", Operation: OperationAll, PatternType: "", Permission: PermissionAllow, Resource: "", ResourceType: ResourceTypeRegistry},
+				{Principal: "User:*", Host: "*", Operation: OperationAll, PatternType: "", Permission: PermissionDeny, Resource: "", ResourceType: ResourceTypeRegistry},
+			},
+		},
+		{
+			name: "deduplicated ACLs for same principal and host",
+			builder: func() *ACLBuilder {
+				return NewACLBuilder().
+					AllowPrincipals("User:alice").
+					AllowHosts("host1").
+					Subjects("topic1", "topic1").
+					Operations(OperationRead, OperationRead).
+					Pattern(PatternTypeLiteral)
+			},
+			exp: []ACL{
+				{Principal: "User:alice", Host: "host1", Operation: OperationRead, PatternType: PatternTypeLiteral, Permission: PermissionAllow, Resource: "topic1", ResourceType: ResourceTypeSubject},
+			},
+		},
+		{
+			name: "registry only with multiple ops",
+			builder: func() *ACLBuilder {
+				return NewACLBuilder().
+					AllowPrincipals("User:admin").
+					AllowHosts("host-1").
+					Registry().
+					Operations(OperationRead, OperationWrite).
+					Pattern(PatternTypeLiteral)
+			},
+			exp: []ACL{
+				{Principal: "User:admin", Host: "host-1", Operation: OperationRead, Permission: PermissionAllow, Resource: "", ResourceType: ResourceTypeRegistry},
+				{Principal: "User:admin", Host: "host-1", Operation: OperationWrite, Permission: PermissionAllow, Resource: "", ResourceType: ResourceTypeRegistry},
+			},
+		},
+		{
+			name: "RedpandaRole subject ACLs",
+			builder: func() *ACLBuilder {
+				return NewACLBuilder().
+					AllowPrincipals("RedpandaRole:admin").
+					AllowHosts("host-2").
+					Subjects("audit").
+					Operations(OperationDescribe).
+					Pattern(PatternTypePrefix)
+			},
+			exp: []ACL{
+				{Principal: "RedpandaRole:admin", Host: "host-2", Operation: OperationDescribe, PatternType: PatternTypePrefix, Permission: PermissionAllow, Resource: "audit", ResourceType: ResourceTypeSubject},
+			},
+		},
+		{
+			name: "wildcard host and principal",
+			builder: func() *ACLBuilder {
+				return NewACLBuilder().
+					AllowPrincipals("User:*").
+					AllowHosts("*").
+					Subjects("logs").
+					Operations(OperationRead).
+					Pattern(PatternTypeLiteral)
+			},
+			exp: []ACL{
+				{Principal: "User:*", Host: "*", Operation: OperationRead, PatternType: PatternTypeLiteral, Permission: PermissionAllow, Resource: "logs", ResourceType: ResourceTypeSubject},
+			},
+		},
+		{
+			name: "deny only subject ACL",
+			builder: func() *ACLBuilder {
+				return NewACLBuilder().
+					DenyPrincipals("User:foo").
+					DenyHosts("10.0.0.1").
+					Subjects("audit").
+					Operations(OperationDescribeConfig).
+					Pattern(PatternTypeLiteral)
+			},
+			exp: []ACL{
+				{Principal: "User:foo", Host: "10.0.0.1", Operation: OperationDescribeConfig, PatternType: PatternTypeLiteral, Permission: PermissionDeny, Resource: "audit", ResourceType: ResourceTypeSubject},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := tt.builder()
+			require.ElementsMatch(t, tt.exp, b.Build())
+		})
+	}
+}

--- a/rpsr/go.mod
+++ b/rpsr/go.mod
@@ -1,0 +1,15 @@
+module github.com/redpanda-data/common-go/rpsr
+
+go 1.24.3
+
+require (
+	github.com/stretchr/testify v1.10.0
+	github.com/twmb/franz-go/pkg/sr v1.4.1-0.20250620172413-c17130ef7765
+	golang.org/x/sync v0.15.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/rpsr/go.sum
+++ b/rpsr/go.sum
@@ -1,0 +1,14 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/twmb/franz-go/pkg/sr v1.4.1-0.20250620172413-c17130ef7765 h1:+l/P3ExNaY1T5Tft/+zK5r7hiEilgHWS5Cjjh2iZ4ME=
+github.com/twmb/franz-go/pkg/sr v1.4.1-0.20250620172413-c17130ef7765/go.mod h1:O4o4mUMNfmyEt2HcuM+qZdc6KrcStvjgxWR6Cfvmukw=
+golang.org/x/sync v0.15.0 h1:KWH3jNZsfyT6xfAfKiz6MRNmd46ByHDYaZ7KSkCtdW8=
+golang.org/x/sync v0.15.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/rpsr/rpsr_test.go
+++ b/rpsr/rpsr_test.go
@@ -1,0 +1,13 @@
+package rpsr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_aclKey_Unique(t *testing.T) {
+	acl1 := ACL{Principal: "fo", Resource: "obar"}
+	acl2 := ACL{Principal: "foo", ResourceType: "bar"}
+	require.NotEqual(t, aclKey(acl1), aclKey(acl2))
+}


### PR DESCRIPTION
This is a client wrapper that extends the franz-go sr client to handle the upcoming Schema Registry ACL endpoints.

It includes a helper ACLBuilder, which allows an ergonomic way of handling ACL creations with optional defaults. The interface and errors are similar to the franz-go acl package, with the difference that here we do not assume any default value and it must be specified.