### PR TITLE
feature: adding ability to call /v1/loggers endpoint to use in rpk

### DIFF
--- a/rpadmin/api_config.go
+++ b/rpadmin/api_config.go
@@ -60,18 +60,17 @@ func (a *AdminAPI) SingleKeyConfig(ctx context.Context, key string) (Config, err
 	return unmarshaled, nil
 }
 
-// Loggerlevel represents the  logger name and level used with the GetLogLevels
+// LLoggerLevel represents the  logger name and level used with the GetLogLevels
 type LoggerLevel struct {
 	Name  string `json:"name"`
 	Level string `json:"level"`
 }
 
-// GetLogLevel obtains the current logger level for the logger `name` for the single admin host in this client.
+// GetLogLevels obtains the current logger level for the logger `name` for the single admin host in this client.
 //
 // This function will return an error if the client
 // has multiple URLs configured.
 func (a *AdminAPI) GetLogLevels(ctx context.Context) ([]LoggerLevel, error) {
-
 	path := "/v1/loggers?include-levels=true"
 	var logLevel []LoggerLevel
 	err := a.sendOne(ctx, http.MethodGet, path, nil, &logLevel, false)

--- a/rpadmin/api_config.go
+++ b/rpadmin/api_config.go
@@ -60,6 +60,24 @@ func (a *AdminAPI) SingleKeyConfig(ctx context.Context, key string) (Config, err
 	return unmarshaled, nil
 }
 
+// Loggerlevel represents the  logger name and level used with the GetLogLevels
+type LoggerLevel struct {
+	Name  string `json:"name"`
+	Level string `json:"level"`
+}
+
+// GetLogLevel obtains the current logger level for the logger `name` for the single admin host in this client.
+//
+// This function will return an error if the client
+// has multiple URLs configured.
+func (a *AdminAPI) GetLogLevels(ctx context.Context) ([]LoggerLevel, error) {
+
+	path := "/v1/loggers?include-levels=true"
+	var logLevel []LoggerLevel
+	err := a.sendOne(ctx, http.MethodGet, path, nil, &logLevel, false)
+	return logLevel, err
+}
+
 // SetLogLevel sets the logger level for the logger `name` to the given level
 // for the single admin host in this client. This function will return an error
 // if the client has multiple URLs configured.

--- a/rpadmin/api_config.go
+++ b/rpadmin/api_config.go
@@ -60,7 +60,7 @@ func (a *AdminAPI) SingleKeyConfig(ctx context.Context, key string) (Config, err
 	return unmarshaled, nil
 }
 
-// LLoggerLevel represents the  logger name and level used with the GetLogLevels
+// LoggerLevel represents the logger name and level used with the GetLogLevels
 type LoggerLevel struct {
 	Name  string `json:"name"`
 	Level string `json:"level"`


### PR DESCRIPTION
We are looking to add the ability to obtain the current log level for 1 or more loggers using rpk. This PR adds the ability to get this information using the /v1/loggers endpoint. With the include-levels=true param, it will return all loggers and the level they are currently set to. 