### PR TITLE
adding new healthoverview with mainenance status

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -56,7 +56,7 @@ linters:
     - rowserrcheck
     - sqlclosecheck
     - stylecheck
-    - tenv
+    - usetesting
     - typecheck
     - unconvert
     - unparam

--- a/rpadmin/go.mod
+++ b/rpadmin/go.mod
@@ -5,8 +5,8 @@ go 1.24.0
 toolchain go1.24.3
 
 require (
-	buf.build/gen/go/redpandadata/core/connectrpc/go v1.18.1-20250903131725-492a4ada6956.1
-	connectrpc.com/connect v1.18.1
+	buf.build/gen/go/redpandadata/core/connectrpc/go v1.19.0-20250923163359-5b43f5e8819f.1
+	connectrpc.com/connect v1.19.0
 	github.com/foxcpp/go-mockdns v1.1.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/redpanda-data/common-go/net v0.1.0
@@ -16,7 +16,7 @@ require (
 )
 
 require (
-	buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.9-20250903131725-492a4ada6956.1 // indirect
+	buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.9-20250923163359-5b43f5e8819f.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/miekg/dns v1.1.57 // indirect
@@ -26,7 +26,7 @@ require (
 	golang.org/x/net v0.37.0 // indirect
 	golang.org/x/sys v0.31.0 // indirect
 	golang.org/x/tools v0.15.0 // indirect
-	google.golang.org/genproto/googleapis/api v0.0.0-20250908214217-97024824d090 // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20250922171735-9219d122eba9 // indirect
 	google.golang.org/protobuf v1.36.9 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/rpadmin/go.sum
+++ b/rpadmin/go.sum
@@ -1,9 +1,15 @@
 buf.build/gen/go/redpandadata/core/connectrpc/go v1.18.1-20250903131725-492a4ada6956.1 h1:ILKCJnvuZt7dVvSrrg96EYHZw+daqVTCj0Wgm+dM1do=
 buf.build/gen/go/redpandadata/core/connectrpc/go v1.18.1-20250903131725-492a4ada6956.1/go.mod h1:kc2N3jlUqEZrUEit1SEEgJrFQ14kk4uIzGHd5Wu5tMI=
+buf.build/gen/go/redpandadata/core/connectrpc/go v1.19.0-20250923163359-5b43f5e8819f.1 h1:tKDypogy6/2SnmdEyRakETCMX2gMuEhmVD9geGvqf1M=
+buf.build/gen/go/redpandadata/core/connectrpc/go v1.19.0-20250923163359-5b43f5e8819f.1/go.mod h1:3xyFIFzXTnLuQRHPmVJqLYgv9cP2GOLTuhIpZ5kOXZk=
 buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.9-20250903131725-492a4ada6956.1 h1:wpCXTU52u2r1XLPsEScI2yZJ5xbxURTJrugu+RflQgE=
 buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.9-20250903131725-492a4ada6956.1/go.mod h1:oupF1xcfwydaQw7rI2idmWZZG7lF/hTF9V6EWSc/UCg=
+buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.9-20250923163359-5b43f5e8819f.1 h1:ftQcNtjB8fvgJId4qF9r7icaG023XU3sl1QIt6yYKEU=
+buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.9-20250923163359-5b43f5e8819f.1/go.mod h1:oupF1xcfwydaQw7rI2idmWZZG7lF/hTF9V6EWSc/UCg=
 connectrpc.com/connect v1.18.1 h1:PAg7CjSAGvscaf6YZKUefjoih5Z/qYkyaTrBW8xvYPw=
 connectrpc.com/connect v1.18.1/go.mod h1:0292hj1rnx8oFrStN7cB4jjVBeqs+Yx5yDIC2prWDO8=
+connectrpc.com/connect v1.19.0 h1:LuqUbq01PqbtL0o7vn0WMRXzR2nNsiINe5zfcJ24pJM=
+connectrpc.com/connect v1.19.0/go.mod h1:tN20fjdGlewnSFeZxLKb0xwIZ6ozc3OQs2hTXy4du9w=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/foxcpp/go-mockdns v1.1.0 h1:jI0rD8M0wuYAxL7r/ynTrCQQq0BVqfB99Vgk7DlmewI=
@@ -97,6 +103,8 @@ golang.org/x/tools v0.15.0/go.mod h1:hpksKq4dtpQWS1uQ61JkdqWM3LscIS6Slf+VVkm+wQk
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/genproto/googleapis/api v0.0.0-20250908214217-97024824d090 h1:d8Nakh1G+ur7+P3GcMjpRDEkoLUcLW2iU92XVqR+XMQ=
 google.golang.org/genproto/googleapis/api v0.0.0-20250908214217-97024824d090/go.mod h1:U8EXRNSd8sUYyDfs/It7KVWodQr+Hf9xtxyxWudSwEw=
+google.golang.org/genproto/googleapis/api v0.0.0-20250922171735-9219d122eba9 h1:jm6v6kMRpTYKxBRrDkYAitNJegUeO1Mf3Kt80obv0gg=
+google.golang.org/genproto/googleapis/api v0.0.0-20250922171735-9219d122eba9/go.mod h1:LmwNphe5Afor5V3R5BppOULHOnt2mCIf+NxMd4XiygE=
 google.golang.org/protobuf v1.36.9 h1:w2gp2mA27hUeUzj9Ex9FBjsBm40zfaDtEWow293U7Iw=
 google.golang.org/protobuf v1.36.9/go.mod h1:fuxRtAxBytpl4zzqUh6/eyUujkJdNiuEkXntxiD/uRU=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=


### PR DESCRIPTION
When running `rpk cluster health` - it would be useful to see if any nodes are in maintenance mode. This new `GetHealthOverviewWithMaintenance` method will include nodes that are in maintenance mode, so it can be displayed when calling `rpk cluster health`