### PR TITLE
rpadmin: add OAUTHBEARER auth option for debug bundle

### DIFF
--- a/rpadmin/api_debug.go
+++ b/rpadmin/api_debug.go
@@ -177,7 +177,7 @@ type DebugPartition struct {
 // debug bundle process.
 // See rpk debug bundle --help
 type debugBundleStartConfigParameters struct {
-	// one of DebugBundleSCRAMAuthentication or DebugBundleOIDCAuthentication
+	// one of debugBundleSCRAMAuthentication or debugBundleOAuthBearerAuthentication
 	Authentication               any                        `json:"authentication,omitempty"`
 	ControllerLogsSizeLimitBytes int32                      `json:"controller_logs_size_limit_bytes,omitempty"`
 	LogsSizeLimitBytes           int32                      `json:"logs_size_limit_bytes,omitempty"`
@@ -206,6 +206,14 @@ type debugBundleSCRAMAuthentication struct {
 	Password  string `json:"password,omitempty"` //nolint:gosec // G117: field holds SCRAM credentials for debug bundle API
 }
 
+// debugBundleOAuthBearerAuthentication are the OAUTHBEARER authentication
+// parameters. The token is the raw OIDC bearer token that the broker-side rpk
+// subprocess will present to Kafka.
+type debugBundleOAuthBearerAuthentication struct {
+	Mechanism string `json:"mechanism,omitempty"`
+	Token     string `json:"token,omitempty"` //nolint:gosec // G117: field holds OIDC bearer token for debug bundle API
+}
+
 type debugBundleStartConfig struct {
 	JobID  string                           `json:"job_id,omitempty"`
 	Config debugBundleStartConfigParameters `json:"config,omitempty"`
@@ -227,6 +235,17 @@ func WithSCRAMAuthentication(username, password, mechanism string) DebugBundleOp
 	return debugBundleOpt{func(param *debugBundleStartConfigParameters) {
 		param.Authentication = debugBundleSCRAMAuthentication{
 			Username: username, Password: password, Mechanism: mechanism,
+		}
+	}}
+}
+
+// WithOAuthBearerAuthentication sets OAUTHBEARER authentication using the
+// given OIDC bearer token.
+func WithOAuthBearerAuthentication(token string) DebugBundleOption {
+	return debugBundleOpt{func(param *debugBundleStartConfigParameters) {
+		param.Authentication = debugBundleOAuthBearerAuthentication{
+			Mechanism: OAuthBearer,
+			Token:     token,
 		}
 	}}
 }

--- a/rpadmin/api_debug.go
+++ b/rpadmin/api_debug.go
@@ -211,7 +211,7 @@ type debugBundleSCRAMAuthentication struct {
 // subprocess will present to Kafka.
 type debugBundleOAuthBearerAuthentication struct {
 	Mechanism string `json:"mechanism,omitempty"`
-	Token     string `json:"token,omitempty"` //nolint:gosec // G117: field holds OIDC bearer token for debug bundle API
+	Token     string `json:"token,omitempty"`
 }
 
 type debugBundleStartConfig struct {

--- a/rpadmin/api_debug_test.go
+++ b/rpadmin/api_debug_test.go
@@ -76,4 +76,22 @@ func TestDebugBundleOption(t *testing.T) {
 		pj, _ := json.Marshal(params)
 		assert.Equal(t, `{"authentication":{"mechanism":"SCRAM-SHA-256","username":"user1","password":"pass1"}}`, string(pj))
 	})
+
+	t.Run("oauthbearer auth", func(t *testing.T) {
+		opts := []DebugBundleOption{
+			WithOAuthBearerAuthentication("my-jwt-token"),
+		}
+		params := &debugBundleStartConfigParameters{}
+		for _, o := range opts {
+			o.apply(params)
+		}
+
+		authBearer, ok := params.Authentication.(debugBundleOAuthBearerAuthentication)
+		assert.True(t, ok)
+		assert.Equal(t, OAuthBearer, authBearer.Mechanism)
+		assert.Equal(t, "my-jwt-token", authBearer.Token)
+
+		pj, _ := json.Marshal(params)
+		assert.Equal(t, `{"authentication":{"mechanism":"OAUTHBEARER","token":"my-jwt-token"}}`, string(pj))
+	})
 }

--- a/rpadmin/api_user.go
+++ b/rpadmin/api_user.go
@@ -32,6 +32,8 @@ const (
 	ScramSha512 = "SCRAM-SHA-512"
 	// CloudOIDC is the constant for CLOUD-OIDC.
 	CloudOIDC = "CLOUD-OIDC"
+	// OAuthBearer is the constant for OAUTHBEARER.
+	OAuthBearer = "OAUTHBEARER"
 )
 
 // CreateUser creates a user with the given username and password using the


### PR DESCRIPTION
## Summary
- Add `WithOAuthBearerAuthentication(token string)` so callers can forward an OIDC bearer token to the broker's `/v1/debug/bundle` endpoint. The existing `WithSCRAMAuthentication` only covers SCRAM profiles, leaving rpk with no way to express OAUTHBEARER credentials to the broker-side rpk subprocess.
- Add a peer payload `debugBundleOAuthBearerAuthentication { mechanism, token }` — sent as `{\"mechanism\":\"OAUTHBEARER\",\"token\":\"<JWT>\"}` on the same ` authentication` field as the existing SCRAM payload.
- Export an `OAuthBearer = \"OAUTHBEARER\"` constant alongside `ScramSha256` / `ScramSha512` / `CloudOIDC`.

## Motivation

Follow-up on review feedback in [redpanda#30169](https://github.com/redpanda-data/redpanda/pull/30169), which adds OAUTHBEARER to rpk's Kafka/admin/Schema Registry clients. In that PR, \`rpk debug remote-bundle start\` silently drops auth for OAUTHBEARER profiles (via \`HasSASLCredentials()\`, which requires both user and password), so requests go to the broker with no auth and fail confusingly on secured clusters.

That PR lands a short-term guard that rejects OAUTHBEARER for remote debug bundle up front with a clear error. This PR unblocks the end-to-end fix by adding the client-side option; the broker-side JSON parser and subprocess arg builder still need to accept the new payload ([tracked in a separate redpanda issue]).

## Test plan
- [x] \`go test ./rpadmin/... -count=1\` passes locally
- [x] New sub-test \`TestDebugBundleOption/oauthbearer_auth\` asserts both the struct discriminator and the serialized JSON
- [ ] Wait for broker-side support before rpk consumes this option

🤖 Generated with [Claude Code](https://claude.com/claude-code)