### PR TITLE
rp-controller-gen: Guard rate-limited heartbeat on rate > 0

### DIFF
--- a/rp-controller-gen/status/templates/status.tpl
+++ b/rp-controller-gen/status/templates/status.tpl
@@ -323,8 +323,11 @@ func setStatusCondition(conditions *[]metav1.Condition, newCondition ratelimited
 		}
     }
     
-    // we force an update of the transition time for the condition
-    if newCondition.rate >= 0 && (time.Since(existingCondition.LastTransitionTime.Time) > newCondition.rate) {
+    // we force an update of the transition time for the condition if an explicit
+    // rate limit is configured (rate > 0). A zero rate means "no rate-limited
+    // heartbeat" — without this guard, time.Since(anything) > 0 would mark the
+    // condition dirty on every reconcile, causing a hot reconcile loop.
+    if newCondition.rate > 0 && (time.Since(existingCondition.LastTransitionTime.Time) > newCondition.rate) {
 		setTransitionTime()
 		changed = true
 	}


### PR DESCRIPTION
## Summary

The `setStatusCondition` template in `rp-controller-gen/status/templates/status.tpl` forces a `LastTransitionTime` update whenever `rate >= 0 && time.Since(LastTransitionTime) > rate`. `getRateLimit` returns `0` for any condition without an explicit rate window, and for rate `0` the guard reduces to:

- `0 >= 0` → true
- `time.Since(anything) > 0` → true

So every reconcile marks the condition dirty, bumps the transition time, forces a status write, and (downstream) re-enqueues reconciliation immediately. This is the root cause of the reconcile loop reported in [redpanda-data/redpanda-operator#1455](https://github.com/redpanda-data/redpanda-operator/issues/1455).

## Change

Tighten the guard to `rate > 0`. The forced-update branch is meant to act as a heartbeat for conditions that opt in to one (License and Configuration in the Redpanda operator); a zero rate means "no heartbeat." Real content changes (Status, Reason, Message, ObservedGeneration) continue to mark the condition dirty through the other branches.

## Test plan

- [x] Matching downstream fix + unit tests in [redpanda-data/redpanda-operator#1460](https://github.com/redpanda-data/redpanda-operator/pull/1460). The downstream tests both fail against this template's current output and pass against the patched output.
- [ ] Reviewer: confirm no other consumer of `rp-controller-gen` relies on the `rate >= 0` behavior. A quick repo search for `rp-controller-gen status` usage should be enough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)