### PR TITLE
rpadmin: add FeaturesService client and upgrade status fields

### DIFF
--- a/rpadmin/adminv2.go
+++ b/rpadmin/adminv2.go
@@ -36,6 +36,11 @@ func (a *AdminAPI) SecurityService(opts ...connect.ClientOption) adminv2connect.
 	return adminv2connect.NewSecurityServiceClient(a, "/", withDefaultClientOpts(opts)...)
 }
 
+// FeaturesService returns a client for the FeaturesService of the Admin API V2.
+func (a *AdminAPI) FeaturesService(opts ...connect.ClientOption) adminv2connect.FeaturesServiceClient {
+	return adminv2connect.NewFeaturesServiceClient(a, "/", withDefaultClientOpts(opts)...)
+}
+
 // newContentTypeInterceptor is a Connect interceptor that sets the Content-Type
 // and Accept headers to "application/proto" for all requests. This ensures that
 // we override the default "application/json" used by some of our shared

--- a/rpadmin/go.mod
+++ b/rpadmin/go.mod
@@ -3,7 +3,7 @@ module github.com/redpanda-data/common-go/rpadmin
 go 1.25.10
 
 require (
-	buf.build/gen/go/redpandadata/core/connectrpc/go v1.19.2-20260506141738-8dfb14358799.1
+	buf.build/gen/go/redpandadata/core/connectrpc/go v1.19.2-20260608080241-5b0ab84ea082.1
 	connectrpc.com/connect v1.19.2
 	github.com/foxcpp/go-mockdns v1.2.0
 	github.com/hashicorp/go-multierror v1.1.1
@@ -17,7 +17,7 @@ require (
 )
 
 require (
-	buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.11-20260506141738-8dfb14358799.1 // indirect
+	buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.11-20260608080241-5b0ab84ea082.1 // indirect
 	dario.cat/mergo v1.0.2 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect

--- a/rpadmin/go.sum
+++ b/rpadmin/go.sum
@@ -1,7 +1,7 @@
-buf.build/gen/go/redpandadata/core/connectrpc/go v1.19.2-20260506141738-8dfb14358799.1 h1:0cW5zcBQS7rT4cNugDJkjEm2Vdr+af25WB/OqKLgelI=
-buf.build/gen/go/redpandadata/core/connectrpc/go v1.19.2-20260506141738-8dfb14358799.1/go.mod h1:Q09oAkV+KV1qms/nPvk6kJ51myCmGKjHCo8dYQ9UNxE=
-buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.11-20260506141738-8dfb14358799.1 h1:v1BvRDJTStoHx54xuGcslo4EurUgVLCjq0oINARzNiQ=
-buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.11-20260506141738-8dfb14358799.1/go.mod h1:5sjUVquVwNxt3Q/EhE/UW0BBJ5sgPiaVTw8//wxRULI=
+buf.build/gen/go/redpandadata/core/connectrpc/go v1.19.2-20260608080241-5b0ab84ea082.1 h1:REoEEpW3VLzOMm1fWkVWCbu7pnHO+OyZdsKL7MT6Chc=
+buf.build/gen/go/redpandadata/core/connectrpc/go v1.19.2-20260608080241-5b0ab84ea082.1/go.mod h1:+xnk83uu51cCNf3Hogv22YnoMkiTXeRMYjsuDMVElKk=
+buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.11-20260608080241-5b0ab84ea082.1 h1:lLdtkh1oXeNO0XDgsarqJ9iR2/RfypaQxz33/D3Z2d0=
+buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.11-20260608080241-5b0ab84ea082.1/go.mod h1:5sjUVquVwNxt3Q/EhE/UW0BBJ5sgPiaVTw8//wxRULI=
 connectrpc.com/connect v1.19.2 h1:McQ83FGdzL+t60peksi0gXC7MQ/iLKgLduAnThbM0mo=
 connectrpc.com/connect v1.19.2/go.mod h1:tN20fjdGlewnSFeZxLKb0xwIZ6ozc3OQs2hTXy4du9w=
 dario.cat/mergo v1.0.2 h1:85+piFYR1tMbRrLcDwR18y4UKJ3aH1Tbzi24VRW1TK8=


### PR DESCRIPTION
## What

Adds Admin API v2 client support for the upgrade-finalization feature
in core ([redpanda#30324](https://github.com/redpanda-data/redpanda/pull/30324)
plus the `GetUpgradeStatus` follow-up).

- `AdminAPI.FeaturesService()` accessor for the v2 `FeaturesService`,
  mirroring the existing `BrokerService()` / `ClusterService()` /
  `SecurityService()` accessors. This exposes the `FinalizeUpgrade`
  (commit a deferred upgrade) and `GetUpgradeStatus` (observe the
  finalization lifecycle) RPCs.
- Bumps the generated `buf.build/redpandadata/core` modules from the
  previously-pinned commit to `5b0ab84ea082`, which includes
  `GetUpgradeStatus` (added to core after the previously-pinned commit).
  `connectrpc.com/connect` stays at v1.19.2. `5b0ab84ea082` is the same
  commit rpk already pins, so consumers stay on one core version; the
  newer published commits add unrelated shadow-link proto fields that
  would drift rpk's shadow command.

## Why

`rpk` will add `rpk cluster upgrade finalize` (calls `FinalizeUpgrade`)
and `rpk cluster upgrade status` (calls `GetUpgradeStatus`). Those
changes depend on this client accessor.

The whole upgrade-finalization surface is connectrpc; the v1 REST
`FeaturesResponse` struct is intentionally left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)