### PR TITLE
[UX-1416] rpadmin: add IcebergService client

### DIFF
--- a/rpadmin/adminv2.go
+++ b/rpadmin/adminv2.go
@@ -41,6 +41,11 @@ func (a *AdminAPI) FeaturesService(opts ...connect.ClientOption) adminv2connect.
 	return adminv2connect.NewFeaturesServiceClient(a, "/", withDefaultClientOpts(opts)...)
 }
 
+// IcebergService returns a client for the IcebergService of the Admin API V2.
+func (a *AdminAPI) IcebergService(opts ...connect.ClientOption) adminv2connect.IcebergServiceClient {
+	return adminv2connect.NewIcebergServiceClient(a, "/", withDefaultClientOpts(opts)...)
+}
+
 // newContentTypeInterceptor is a Connect interceptor that sets the Content-Type
 // and Accept headers to "application/proto" for all requests. This ensures that
 // we override the default "application/json" used by some of our shared

--- a/rpadmin/go.mod
+++ b/rpadmin/go.mod
@@ -3,8 +3,8 @@ module github.com/redpanda-data/common-go/rpadmin
 go 1.25.10
 
 require (
-	buf.build/gen/go/redpandadata/core/connectrpc/go v1.19.2-20260608080241-5b0ab84ea082.1
-	connectrpc.com/connect v1.19.2
+	buf.build/gen/go/redpandadata/core/connectrpc/go v1.20.0-20260714112317-973b760dcc8a.1
+	connectrpc.com/connect v1.20.0
 	github.com/foxcpp/go-mockdns v1.2.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/redpanda-data/common-go/net v0.1.0
@@ -17,7 +17,7 @@ require (
 )
 
 require (
-	buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.11-20260608080241-5b0ab84ea082.1 // indirect
+	buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.11-20260714112317-973b760dcc8a.1 // indirect
 	dario.cat/mergo v1.0.2 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect

--- a/rpadmin/go.sum
+++ b/rpadmin/go.sum
@@ -1,9 +1,9 @@
-buf.build/gen/go/redpandadata/core/connectrpc/go v1.19.2-20260608080241-5b0ab84ea082.1 h1:REoEEpW3VLzOMm1fWkVWCbu7pnHO+OyZdsKL7MT6Chc=
-buf.build/gen/go/redpandadata/core/connectrpc/go v1.19.2-20260608080241-5b0ab84ea082.1/go.mod h1:+xnk83uu51cCNf3Hogv22YnoMkiTXeRMYjsuDMVElKk=
-buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.11-20260608080241-5b0ab84ea082.1 h1:lLdtkh1oXeNO0XDgsarqJ9iR2/RfypaQxz33/D3Z2d0=
-buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.11-20260608080241-5b0ab84ea082.1/go.mod h1:5sjUVquVwNxt3Q/EhE/UW0BBJ5sgPiaVTw8//wxRULI=
-connectrpc.com/connect v1.19.2 h1:McQ83FGdzL+t60peksi0gXC7MQ/iLKgLduAnThbM0mo=
-connectrpc.com/connect v1.19.2/go.mod h1:tN20fjdGlewnSFeZxLKb0xwIZ6ozc3OQs2hTXy4du9w=
+buf.build/gen/go/redpandadata/core/connectrpc/go v1.20.0-20260714112317-973b760dcc8a.1 h1:y/s+d4Rs8VOJmZ9XWGtlIryBS9KjW7tw/91DXq4zmbY=
+buf.build/gen/go/redpandadata/core/connectrpc/go v1.20.0-20260714112317-973b760dcc8a.1/go.mod h1:6Gz1o83Z3bQPmM5s8IM5gISZ/WKcJ5dj00FKvw6sU8E=
+buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.11-20260714112317-973b760dcc8a.1 h1:EZf0jhr/+S98atH0Y5MFbNRbLtUTOemtDq39+fQCnd0=
+buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.11-20260714112317-973b760dcc8a.1/go.mod h1:5sjUVquVwNxt3Q/EhE/UW0BBJ5sgPiaVTw8//wxRULI=
+connectrpc.com/connect v1.20.0 h1:6TNDAB+WeNd2uolWNlYczB5E0KNNaVMNUEx8JEUsPmQ=
+connectrpc.com/connect v1.20.0/go.mod h1:A2ygJrukXwWy32vkCAAHNVguZrqZ+jeZ9rGRnGR4dN4=
 dario.cat/mergo v1.0.2 h1:85+piFYR1tMbRrLcDwR18y4UKJ3aH1Tbzi24VRW1TK8=
 dario.cat/mergo v1.0.2/go.mod h1:E/hbnu0NxMFBjpMIE34DRGLWqDy0g5FuKDhCb31ngxA=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6 h1:He8afgbRMd7mFxO99hRNu+6tazq8nFF9lIwo9JFroBk=


### PR DESCRIPTION
Adds an `IcebergService()` accessor to the Admin API V2 client, following the same pattern as the existing service accessors.

- Bump `buf.build/gen/go/redpandadata/core` generated packages to the latest snapshot (which introduces `IcebergService`)
- Bump `connectrpc.com/connect` v1.19.2 → v1.20.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)