### PR TITLE
feat(ocsf): support merged-only and read-mask generator output

### DIFF
--- a/ocsf/README.md
+++ b/ocsf/README.md
@@ -16,11 +16,12 @@ exported as OCSF JSON at the boundary.
 Two artifacts are the point of this module; two more keep them safe to evolve.
 
 1. **Proto source files** under `ocsf/v<N>/`: one message per selected class
-   plus the merged single-event message, all sharing `objects.proto`. Fields
-   carry wire-stable numbers from the tagmap and `buf.validate` annotations
-   (required levels, plus class-aware CEL rules on the merged message), so
-   protovalidate enforces OCSF semantics on every event before it is
-   published. With `--merged-sr-subject`, the merged message also carries the
+   and, when requested, the merged single-event message, all sharing
+   `objects.proto`. `--merged-only` suppresses the per-class files. Fields carry
+   wire-stable numbers from the tagmap and `buf.validate` annotations (required
+   levels, plus class-aware CEL rules on the merged message), so protovalidate
+   enforces OCSF semantics on every event before it is published. With
+   `--merged-sr-subject`, the merged message also carries the
    `(redpanda.api.common.v1.schema_registry)` annotation that drives
    `protoc-gen-go-sr-normalize`.
 2. **Generated Go code**, produced from those protos with `buf generate` and
@@ -35,7 +36,8 @@ Two artifacts are the point of this module; two more keep them safe to evolve.
    Register as-is. Each one gets a `<name>.sr.go` companion embedding the
    schema text (and, for the merged message, the subject) as Go constants
    (`<MessageName>SRSchema`, `<MessageName>SRSubject`), so consumers never
-   hand-embed the proto text.
+   hand-embed the proto text. `--sr-go-only` emits only those Go companions
+   when consumers do not need the intermediate `.sr.proto` files.
 4. **The tagmap** (`field-numbers.json`): the append-only field-number map
    that keeps every regeneration wire-compatible with the previous one,
    enforced in CI by `--compat-check`.
@@ -46,9 +48,9 @@ Two artifacts are the point of this module; two more keep them safe to evolve.
 
 ### Layouts
 
-The generator emits two layouts from one tagmap:
+The generator can emit two layouts from one tagmap:
 
-- **Per-class** (always): one message per class (`ApiActivity`,
+- **Per-class** (default): one message per class (`ApiActivity`,
   `EntityManagement`, ...), one file each, plus a shared `objects.proto`.
 - **Merged single-event** (`--merged-message AuditEvent`): ONE flat message
   holding the union of all selected classes' attributes, for a single
@@ -59,6 +61,9 @@ The generator emits two layouts from one tagmap:
   validation is generated as protovalidate CEL: `type_uid == class_uid * 100 +
   activity_id`, per-class field ownership, and per-class requiredness. A
   merged event exports OCSF JSON identical to the per-class message.
+
+By default, `--merged-message` adds the merged layout alongside the per-class
+layout. `--merged-only` emits only the merged message and `objects.proto`.
 
 ### Packages
 
@@ -84,12 +89,17 @@ go run ./cmd/ocsf-protogen \
   --out     out-dir \
   --tagmap  field-numbers.json \
   --merged-message AuditEvent \
-  --sr-schema-out sr-dir
+  --merged-only \
+  --sr-schema-out sr-dir \
+  --sr-go-only
 ```
 
 - `--merged-message <Name>` additionally emits the merged single-event layout
   (`ocsf/v<N>/<snake_name>.proto`, and `<snake_name>.sr.proto` under
   `--sr-schema-out`).
+- `--merged-only` suppresses the per-class proto and Schema Registry files,
+  leaving the merged message and shared `objects.proto`. Requires
+  `--merged-message`.
 - `--merged-sr-subject <subject>` annotates the merged message with
   `(redpanda.api.common.v1.schema_registry) = { subject: "..." }` (from
   `buf.build/redpandadata/common`). Consumers that run
@@ -104,6 +114,9 @@ go run ./cmd/ocsf-protogen \
   prefer the annotation plus `protoc-gen-go-sr-normalize`.
 - `--sr-go-package <name>` sets the Go package of the `.sr.go` companions.
   Default is derived from the OCSF major version: `1.8.0` → `ocsfv1`.
+- `--sr-go-only` writes only the `.sr.go` schema embeds under
+  `--sr-schema-out`, omitting their intermediate `.sr.proto` files. Requires
+  `--sr-schema-out`.
 - `--iceberg-compat` prunes the schema model before emission so the merged
   event topic can be Iceberg-enabled and queried from Oxla (see below).
 - `--check` regenerates and fails on output drift or newly-stubbed objects.

--- a/ocsf/README.md
+++ b/ocsf/README.md
@@ -45,6 +45,10 @@ Two artifacts are the point of this module; two more keep them safe to evolve.
    (`ocsf/v<N>/iceberg-compat-prunes.txt`), one sorted
    `<Message>.<field> <rule>` line per field dropped from the emitted protos,
    so fidelity loss is diffable across OCSF versions.
+6. With `--mask-file`: **the read-mask report**
+   (`ocsf/v<N>/read-mask-report.txt`), the resolved keep set plus every leaf
+   column the mask kept without being asked to, so the published contract is
+   reviewable as a diff.
 
 ### Layouts
 
@@ -119,9 +123,83 @@ go run ./cmd/ocsf-protogen \
   `--sr-schema-out`.
 - `--iceberg-compat` prunes the schema model before emission so the merged
   event topic can be Iceberg-enabled and queried from Oxla (see below).
+- `--mask-file <path>` narrows the schema to an allowlist of attribute paths
+  before anything else runs (see below).
 - `--check` regenerates and fails on output drift or newly-stubbed objects.
 - `--compat-check --old <a> --new <b>` fails if field numbers changed
   incompatibly between two tag maps (used in CI against the base branch).
+
+### `--mask-file` (read mask)
+
+An OCSF class is enormous: `api_activity` + `entity_management` reach ~100
+message types and thousands of leaf columns, while a typical producer populates
+a few dozen fields. Publishing the whole thing costs every consumer — and an
+Iceberg-enabled topic pays for it per column on `REFRESH`.
+
+`--mask-file` takes an allowlist of root-relative attribute paths and drops
+everything else from the model before any emission, so the per-class protos, the
+merged message, the SR schemas and the validation rules all describe the same
+narrowed contract:
+
+```yaml
+version: 1
+paths:
+  - time
+  - actor.user.email_addr
+  - api.response.code
+  - metadata.*
+```
+
+- A path ending in `.*` keeps a message-typed field's **whole subtree**
+  (transitively). Any other path must end on a scalar; stopping on a
+  message-typed field is an error that names the fix, so a mask cannot silently
+  produce an empty message.
+- The mask is **closed upward**: list leaves, not prefixes. `actor.user.email_addr`
+  retains the `actor` and `actor.user` edges automatically.
+- A path that does not resolve against the schema **fails generation**. That is
+  the point of an allowlist: an OCSF rename stops matching, and CI says so
+  instead of quietly dropping a column consumers query.
+- Constraints (`at_least_one` / `just_one`) naming a dropped attribute are
+  scrubbed, so the emitted CEL never references a field that no longer exists.
+- With `--merged-message`, the class discriminators (`category_uid`,
+  `class_uid`, `type_uid`) may not be masked away: the merged emitter gates its
+  CEL on `class_uid` and readers demux the single topic on the trio.
+
+**Type-scoped semantics.** Paths are written root-relative because that is how
+consumers think about the event, but they are applied per message **type**:
+`actor.user.email_addr` keeps `User.email_addr` wherever `User` is embedded. The
+schema model is a graph of shared object types, so a per-path mask would mean
+specialising a type per embedding path — a message explosion that would also
+break the tagmap's `(message, attribute)` identity. The gap is reported rather
+than hidden: every leaf column the output carries that no path asked for is
+listed in the widening section of `read-mask-report.txt`. In practice the gap is
+small, because sharing falls away as paths are closed — a type embedded at
+fifteen paths in the full schema is usually reachable by one after masking.
+
+**Wire stability.** Masking never renumbers. Excluded attributes are simply
+never assigned, so they keep their `field-numbers.json` entries, the tagmap file
+does not shrink, `--compat-check` stays clean, and **un-masking a field later
+restores its original field number**. Starting narrow is therefore cheap and
+reversible: adding this mask to an existing baseline leaves the committed tagmap
+byte-identical.
+
+> **Do not regenerate `field-numbers.json` from scratch once a mask is in
+> place.** The tagmap is what carries the excluded fields' numbers; bootstrapping
+> a fresh one under a mask assigns the surviving fields compact numbers from 1
+> instead, silently renumbering the whole schema. CI's `--compat-check` against
+> the base branch catches exactly this, which is why that gate matters more once
+> a mask exists.
+
+**Ordering.** The mask runs before `--iceberg-compat`, and that ordering pays:
+the prune rules react to the shape of the model (R3 demotes an edge because a
+dotted path overflows 63 chars, R4 drops edges to emptied types), so removing
+the deep subtrees first means far fewer fields have to collapse into JSON
+strings. On the OCSF 1.8.0 fixture the mask above takes `--iceberg-compat` from
+55 demotions to 3.
+
+The mask itself is consumer policy, not generator knowledge: which fields you
+publish belongs in your repo next to your committed output, the same way
+`--classes` and `--merged-message` do.
 
 ### `--iceberg-compat`
 

--- a/ocsf/README.md
+++ b/ocsf/README.md
@@ -36,8 +36,7 @@ Two artifacts are the point of this module; two more keep them safe to evolve.
    Register as-is. Each one gets a `<name>.sr.go` companion embedding the
    schema text (and, for the merged message, the subject) as Go constants
    (`<MessageName>SRSchema`, `<MessageName>SRSubject`), so consumers never
-   hand-embed the proto text. `--sr-go-only` emits only those Go companions
-   when consumers do not need the intermediate `.sr.proto` files.
+   hand-embed the proto text.
 4. **The tagmap** (`field-numbers.json`): the append-only field-number map
    that keeps every regeneration wire-compatible with the previous one,
    enforced in CI by `--compat-check`.
@@ -94,8 +93,7 @@ go run ./cmd/ocsf-protogen \
   --tagmap  field-numbers.json \
   --merged-message AuditEvent \
   --merged-only \
-  --sr-schema-out sr-dir \
-  --sr-go-only
+  --sr-schema-out sr-dir
 ```
 
 - `--merged-message <Name>` additionally emits the merged single-event layout
@@ -118,30 +116,27 @@ go run ./cmd/ocsf-protogen \
   prefer the annotation plus `protoc-gen-go-sr-normalize`.
 - `--sr-go-package <name>` sets the Go package of the `.sr.go` companions.
   Default is derived from the OCSF major version: `1.8.0` → `ocsfv1`.
-- `--sr-go-only` writes only the `.sr.go` schema embeds under
-  `--sr-schema-out`, omitting their intermediate `.sr.proto` files. Requires
-  `--sr-schema-out`.
 - `--iceberg-compat` prunes the schema model before emission so the merged
   event topic can be Iceberg-enabled and queried from Oxla (see below).
 - `--mask-file <path>` narrows the schema to an allowlist of attribute paths
   before anything else runs (see below).
 - `--check` regenerates and fails on output drift, stray artifacts, or
   newly-stubbed objects.
+- `--compat-check --old <a> --new <b>` fails if field numbers changed
+  incompatibly between two tag maps (used in CI against the base branch).
 
 Generation **reconciles** its output directories: a generator-managed artifact
 that the current run no longer produces is deleted, so narrowing the output
-(`--merged-only`, `--sr-go-only`, dropping `--mask-file`) is an ordinary
-regenerate-and-commit. Without that, switching an existing baseline to a narrower
-layout left the old files behind and `--check` rejected them as strays with no
-way to regenerate them away.
+(`--merged-only`, dropping `--mask-file`) is an ordinary regenerate-and-commit.
+Without that, switching an existing baseline to a narrower layout left the old
+files behind and `--check` rejected them as strays with no way to regenerate them
+away.
 
 Deletion is confined to the directories the generator writes into and to the
 names it owns — `*.proto` plus `iceberg-compat-prunes.txt` and
 `read-mask-report.txt` under `ocsf/v<N>/`, and `*.sr.proto`/`*.sr.go` under
 `--sr-schema-out`. `buf.yaml`, `buf.lock`, the tagmap and anything hand-added are
 never candidates.
-- `--compat-check --old <a> --new <b>` fails if field numbers changed
-  incompatibly between two tag maps (used in CI against the base branch).
 
 ### `--mask-file` (read mask)
 

--- a/ocsf/README.md
+++ b/ocsf/README.md
@@ -176,19 +176,26 @@ listed in the widening section of `read-mask-report.txt`. In practice the gap is
 small, because sharing falls away as paths are closed — a type embedded at
 fifteen paths in the full schema is usually reachable by one after masking.
 
-**Wire stability.** Masking never renumbers. Excluded attributes are simply
-never assigned, so they keep their `field-numbers.json` entries, the tagmap file
-does not shrink, `--compat-check` stays clean, and **un-masking a field later
-restores its original field number**. Starting narrow is therefore cheap and
-reversible: adding this mask to an existing baseline leaves the committed tagmap
-byte-identical.
+**Wire stability.** Masking never renumbers. Tags are reserved over the
+*unmasked* model before the mask is applied (`gen.ReserveTags`), so field numbers
+are a function of the OCSF schema and the class selection alone — never of what
+the mask chose to emit. Consequences:
 
-> **Do not regenerate `field-numbers.json` from scratch once a mask is in
-> place.** The tagmap is what carries the excluded fields' numbers; bootstrapping
-> a fresh one under a mask assigns the surviving fields compact numbers from 1
-> instead, silently renumbering the whole schema. CI's `--compat-check` against
-> the base branch catches exactly this, which is why that gate matters more once
-> a mask exists.
+- Adding a mask to an existing baseline leaves the committed tagmap
+  byte-identical.
+- A tagmap bootstrapped with a mask active is identical to one bootstrapped
+  without it, so regenerating it is not destructive.
+- **Un-masking a field later restores its original field number**, because the
+  excluded attributes keep their recorded entries.
+
+Starting narrow is therefore cheap and reversible.
+
+> `field-numbers.json` must still be committed. Reserving is deterministic only
+> for a *fixed* OCSF version: a new release that inserts an alphabetically-early
+> attribute would shift every later number, and the committed tagmap is the only
+> thing that prevents that (the new attribute takes the lowest free number
+> instead). It is also the only record of `reserved` numbers retired fields must
+> never give up. CI's `--compat-check` against the base branch is the gate.
 
 **Ordering.** The mask runs before `--iceberg-compat`, and that ordering pays:
 the prune rules react to the shape of the model (R3 demotes an edge because a

--- a/ocsf/README.md
+++ b/ocsf/README.md
@@ -125,7 +125,21 @@ go run ./cmd/ocsf-protogen \
   event topic can be Iceberg-enabled and queried from Oxla (see below).
 - `--mask-file <path>` narrows the schema to an allowlist of attribute paths
   before anything else runs (see below).
-- `--check` regenerates and fails on output drift or newly-stubbed objects.
+- `--check` regenerates and fails on output drift, stray artifacts, or
+  newly-stubbed objects.
+
+Generation **reconciles** its output directories: a generator-managed artifact
+that the current run no longer produces is deleted, so narrowing the output
+(`--merged-only`, `--sr-go-only`, dropping `--mask-file`) is an ordinary
+regenerate-and-commit. Without that, switching an existing baseline to a narrower
+layout left the old files behind and `--check` rejected them as strays with no
+way to regenerate them away.
+
+Deletion is confined to the directories the generator writes into and to the
+names it owns — `*.proto` plus `iceberg-compat-prunes.txt` and
+`read-mask-report.txt` under `ocsf/v<N>/`, and `*.sr.proto`/`*.sr.go` under
+`--sr-schema-out`. `buf.yaml`, `buf.lock`, the tagmap and anything hand-added are
+never candidates.
 - `--compat-check --old <a> --new <b>` fails if field numbers changed
   incompatibly between two tag maps (used in CI against the base branch).
 

--- a/ocsf/cmd/ocsf-protogen/main.go
+++ b/ocsf/cmd/ocsf-protogen/main.go
@@ -61,8 +61,7 @@
 //
 // When --sr-schema-out is set, each emitted <name>.sr.proto gets a companion
 // <name>.sr.go embedding the schema text (and, for the merged message, the
-// subject) as Go constants; --sr-go-only suppresses the intermediate
-// .sr.proto files, and --sr-go-package overrides the Go package name.
+// subject) as Go constants; --sr-go-package overrides the Go package name.
 //
 // Check mode (for CI — verifies committed baseline is up-to-date):
 //
@@ -132,7 +131,6 @@ func run(args []string) error {
 	mergedSRSubjectFlag := fs.String("merged-sr-subject", "", "optional Schema Registry subject; annotates the merged message with (redpanda.api.common.v1.schema_registry) for protoc-gen-go-sr-normalize (requires --merged-message)")
 	icebergCompatFlag := fs.Bool("iceberg-compat", false, "prune fields Redpanda Iceberg/Oxla cannot represent (google.protobuf.Value fields, recursion back-edges, dotted field paths over 63 chars) before emission; writes ocsf/v<N>/iceberg-compat-prunes.txt")
 	srGoPackageFlag := fs.String("sr-go-package", "", "Go package name for the generated <name>.sr.go companions under --sr-schema-out (default: derived from the OCSF major version, e.g. ocsfv1)")
-	srGoOnlyFlag := fs.Bool("sr-go-only", false, "emit only the .sr.go schema embeds under --sr-schema-out, suppressing the intermediate .sr.proto files")
 	maskFileFlag := fs.String("mask-file", "", "optional read-mask YAML listing the root-relative attribute paths to keep (e.g. actor.user.email_addr, metadata.*); everything else is dropped before emission and ocsf/v<N>/read-mask-report.txt records the result")
 
 	if err := fs.Parse(args); err != nil {
@@ -180,7 +178,6 @@ func run(args []string) error {
 		MergedSRSubject: *mergedSRSubjectFlag,
 		IcebergCompat:   *icebergCompatFlag,
 		SRGoPackage:     *srGoPackageFlag,
-		SRGoOnly:        *srGoOnlyFlag,
 		MaskPath:        *maskFileFlag,
 	}
 

--- a/ocsf/cmd/ocsf-protogen/main.go
+++ b/ocsf/cmd/ocsf-protogen/main.go
@@ -37,6 +37,28 @@
 // and fields whose dotted path from a root exceeds 63 chars are removed. The
 // pruned fields are recorded in <out>/ocsf/v<N>/iceberg-compat-prunes.txt.
 //
+// --mask-file narrows the schema to an allowlist of root-relative attribute
+// paths (a "read mask") before anything else runs, so the whole OCSF class need
+// not be published to use one field of it:
+//
+//	version: 1
+//	paths:
+//	  - time
+//	  - actor.user.email_addr
+//	  - metadata.*
+//
+// A path ending in ".*" keeps a message-typed field's whole subtree; any other
+// path must end on a scalar. Paths are applied per message TYPE, so
+// actor.user.email_addr keeps User.email_addr wherever User is embedded; every
+// leaf column that no path asked for is listed in the widening section of
+// <out>/ocsf/v<N>/read-mask-report.txt. A path that does not resolve against the
+// schema is an error, so a renamed OCSF attribute fails generation rather than
+// silently narrowing the published contract.
+//
+// Masking never renumbers: excluded attributes keep their --tagmap entries, so
+// --compat-check stays clean and un-masking a field later restores its original
+// field number.
+//
 // When --sr-schema-out is set, each emitted <name>.sr.proto gets a companion
 // <name>.sr.go embedding the schema text (and, for the merged message, the
 // subject) as Go constants; --sr-go-only suppresses the intermediate
@@ -111,6 +133,7 @@ func run(args []string) error {
 	icebergCompatFlag := fs.Bool("iceberg-compat", false, "prune fields Redpanda Iceberg/Oxla cannot represent (google.protobuf.Value fields, recursion back-edges, dotted field paths over 63 chars) before emission; writes ocsf/v<N>/iceberg-compat-prunes.txt")
 	srGoPackageFlag := fs.String("sr-go-package", "", "Go package name for the generated <name>.sr.go companions under --sr-schema-out (default: derived from the OCSF major version, e.g. ocsfv1)")
 	srGoOnlyFlag := fs.Bool("sr-go-only", false, "emit only the .sr.go schema embeds under --sr-schema-out, suppressing the intermediate .sr.proto files")
+	maskFileFlag := fs.String("mask-file", "", "optional read-mask YAML listing the root-relative attribute paths to keep (e.g. actor.user.email_addr, metadata.*); everything else is dropped before emission and ocsf/v<N>/read-mask-report.txt records the result")
 
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -158,6 +181,7 @@ func run(args []string) error {
 		IcebergCompat:   *icebergCompatFlag,
 		SRGoPackage:     *srGoPackageFlag,
 		SRGoOnly:        *srGoOnlyFlag,
+		MaskPath:        *maskFileFlag,
 	}
 
 	if cfg.Check {

--- a/ocsf/cmd/ocsf-protogen/main.go
+++ b/ocsf/cmd/ocsf-protogen/main.go
@@ -8,8 +8,8 @@
 // by the Apache License, Version 2.0
 
 // Command ocsf-protogen generates proto3 definitions from a compiled OCSF
-// schema JSON export: per-class messages, the merged single-event message
-// (--merged-message), and self-contained Schema-Registry schemas
+// schema JSON export: per-class messages, an optional merged single-event
+// message (--merged-message), and self-contained Schema-Registry schemas
 // (--sr-schema-out). The emitted protos carry buf.validate annotations; Go
 // bindings are generated from them with buf + protoc-gen-go (see
 // internal/ocsf/conformance/genpb/buf.gen*.yaml for the reference recipe).
@@ -23,12 +23,13 @@
 //	  --out     ocsf/cmd/ocsf-protogen/testdata \
 //	  --tagmap  ocsf/cmd/ocsf-protogen/testdata/field-numbers.json \
 //	  --merged-message AuditEvent \
+//	  --merged-only \
 //	  --merged-sr-subject redpanda.ocsf.audit-events-value
 //
 // --out is a MODULE ROOT DIRECTORY. Files are written under it at their
 // module-relative paths, e.g. <out>/ocsf/v1/api_activity.proto,
 // <out>/ocsf/v1/entity_management.proto, <out>/ocsf/v1/audit_event.proto,
-// <out>/ocsf/v1/objects.proto.
+// <out>/ocsf/v1/objects.proto. --merged-only suppresses the per-class files.
 //
 // --iceberg-compat prunes the schema model before emission so the generated
 // protos can be translated to Iceberg by Redpanda and read by Oxla: fields
@@ -36,9 +37,10 @@
 // and fields whose dotted path from a root exceeds 63 chars are removed. The
 // pruned fields are recorded in <out>/ocsf/v<N>/iceberg-compat-prunes.txt.
 //
-// When --sr-schema-out is set, each <name>.sr.proto gets a companion
+// When --sr-schema-out is set, each emitted <name>.sr.proto gets a companion
 // <name>.sr.go embedding the schema text (and, for the merged message, the
-// subject) as Go constants; --sr-go-package overrides its package name.
+// subject) as Go constants; --sr-go-only suppresses the intermediate
+// .sr.proto files, and --sr-go-package overrides the Go package name.
 //
 // Check mode (for CI — verifies committed baseline is up-to-date):
 //
@@ -104,9 +106,11 @@ func run(args []string) error {
 	newFlag := fs.String("new", "", "path to the PR tagmap JSON (for --compat-check)")
 	srSchemaOutFlag := fs.String("sr-schema-out", "", "optional directory for self-contained Schema-Registry schemas (<class>.sr.proto); empty disables SR emission")
 	mergedMessageFlag := fs.String("merged-message", "", "optional message name (e.g. AuditEvent) for a single flat message unioning all selected classes, emitted alongside the per-class files; empty disables merged emission")
+	mergedOnlyFlag := fs.Bool("merged-only", false, "emit only the merged message and shared objects, suppressing per-class proto and Schema Registry files (requires --merged-message)")
 	mergedSRSubjectFlag := fs.String("merged-sr-subject", "", "optional Schema Registry subject; annotates the merged message with (redpanda.api.common.v1.schema_registry) for protoc-gen-go-sr-normalize (requires --merged-message)")
 	icebergCompatFlag := fs.Bool("iceberg-compat", false, "prune fields Redpanda Iceberg/Oxla cannot represent (google.protobuf.Value fields, recursion back-edges, dotted field paths over 63 chars) before emission; writes ocsf/v<N>/iceberg-compat-prunes.txt")
 	srGoPackageFlag := fs.String("sr-go-package", "", "Go package name for the generated <name>.sr.go companions under --sr-schema-out (default: derived from the OCSF major version, e.g. ocsfv1)")
+	srGoOnlyFlag := fs.Bool("sr-go-only", false, "emit only the .sr.go schema embeds under --sr-schema-out, suppressing the intermediate .sr.proto files")
 
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -149,9 +153,11 @@ func run(args []string) error {
 		Check:           *checkFlag,
 		SRSchemaOutDir:  *srSchemaOutFlag,
 		MergedMessage:   *mergedMessageFlag,
+		MergedOnly:      *mergedOnlyFlag,
 		MergedSRSubject: *mergedSRSubjectFlag,
 		IcebergCompat:   *icebergCompatFlag,
 		SRGoPackage:     *srGoPackageFlag,
+		SRGoOnly:        *srGoOnlyFlag,
 	}
 
 	if cfg.Check {

--- a/ocsf/cmd/ocsf-protogen/protogen/protogen.go
+++ b/ocsf/cmd/ocsf-protogen/protogen/protogen.go
@@ -71,10 +71,6 @@ type Config struct {
 	// SRSchemaOutDir. Empty derives the name from the schema version's major
 	// component ("1.8.0" → "ocsfv1"). Only used when SRSchemaOutDir is set.
 	SRGoPackage string
-	// SRGoOnly, when true, writes only the generated <name>.sr.go schema
-	// embeds under SRSchemaOutDir and suppresses their intermediate
-	// <name>.sr.proto files. Requires SRSchemaOutDir.
-	SRGoOnly bool
 	// MaskPath, when non-empty, is the path to a read-mask YAML file listing
 	// the root-relative attribute paths to keep. Everything else is dropped
 	// from the model BEFORE any emission, so the per-class protos, the merged
@@ -294,15 +290,13 @@ func applyMask(s *schema.Schema, cfg Config) (gen.GeneratedFile, error) {
 	if err != nil {
 		return gen.GeneratedFile{}, fmt.Errorf("mask report: %w", err)
 	}
+	// One line, matching the iceberg-compat prune line: the detail lives in the
+	// committed report, this is just the headline an operator wants after running
+	// generate.
 	fmt.Fprintf(os.Stderr,
-		"read-mask: kept %d fields; leaf columns %d -> %d, message types %d -> %d (see %s)\n",
-		len(res.Kept), res.Stats.LeafPathsBefore, res.Stats.LeafPathsAfter,
+		"read-mask: kept %d fields, %d widened; leaf columns %d -> %d, message types %d -> %d (see %s)\n",
+		len(res.Kept), len(res.Widened), res.Stats.LeafPathsBefore, res.Stats.LeafPathsAfter,
 		res.Stats.MessagesBefore, res.Stats.MessagesAfter, f.Path)
-	if len(res.Widened) > 0 {
-		fmt.Fprintf(os.Stderr,
-			"read-mask: %d leaf columns kept that no mask path asked for (shared types); see the report\n",
-			len(res.Widened))
-	}
 	return f, nil
 }
 
@@ -391,9 +385,6 @@ func emitAllSRSchemas(s *schema.Schema, cfg Config, tm *tagmap.TagMap) ([]gen.Ge
 		goFiles = append(goFiles, goFile)
 	}
 	srFiles = append(srFiles, goFiles...)
-	if cfg.SRGoOnly {
-		srFiles = goFiles
-	}
 
 	sort.Slice(srFiles, func(i, j int) bool { return srFiles[i].Path < srFiles[j].Path })
 	if cfg.IcebergCompat {
@@ -423,8 +414,8 @@ func writeFiles(outDir string, files []gen.GeneratedFile) error {
 // syncFiles writes files under root and then removes generator-managed artifacts
 // in the same directories that this run no longer produces.
 //
-// Without the removal step, narrowing the output (--merged-only, --sr-go-only,
-// --mask-file) leaves the previous layout's files on disk: --check reports them
+// Without the removal step, narrowing the output (--merged-only, --mask-file)
+// leaves the previous layout's files on disk: --check reports them
 // as strays, and its advice to "regenerate without --check" cannot clear them.
 // Reconciling makes broad -> narrow the ordinary regenerate-and-commit flow.
 //
@@ -443,6 +434,7 @@ func syncFiles(root string, files []gen.GeneratedFile, managed func(base string)
 		dirs[path.Dir(f.Path)] = struct{}{}
 	}
 
+	var removed []string
 	for dir := range dirs {
 		abs := filepath.Join(root, filepath.FromSlash(dir))
 		entries, err := os.ReadDir(abs)
@@ -466,8 +458,17 @@ func syncFiles(root string, files []gen.GeneratedFile, managed func(base string)
 			if err := os.Remove(filepath.Join(abs, e.Name())); err != nil {
 				return fmt.Errorf("remove stale generated file %q: %w", rel, err)
 			}
-			fmt.Fprintf(os.Stderr, "removed stale generated file %s\n", rel)
+			removed = append(removed, rel)
 		}
+	}
+
+	// Report deletions in one line — they are the surprising part of a generate
+	// run, so they are named rather than merely counted, but a narrowing
+	// transition can drop a dozen files and should not bury the rest of the output.
+	if len(removed) > 0 {
+		sort.Strings(removed)
+		fmt.Fprintf(os.Stderr, "removed %d stale generated file(s): %s\n",
+			len(removed), strings.Join(removed, ", "))
 	}
 	return nil
 }
@@ -558,9 +559,6 @@ func Check(cfg Config) error {
 func validateConfig(cfg Config) error {
 	if cfg.MergedOnly && strings.TrimSpace(cfg.MergedMessage) == "" {
 		return errors.New("--merged-only requires --merged-message")
-	}
-	if cfg.SRGoOnly && strings.TrimSpace(cfg.SRSchemaOutDir) == "" {
-		return errors.New("--sr-go-only requires --sr-schema-out")
 	}
 	return nil
 }

--- a/ocsf/cmd/ocsf-protogen/protogen/protogen.go
+++ b/ocsf/cmd/ocsf-protogen/protogen/protogen.go
@@ -47,6 +47,10 @@ type Config struct {
 	// When SRSchemaOutDir is also set, a merged <snake_case_name>.sr.proto is
 	// written there too. Empty disables merged emission.
 	MergedMessage string
+	// MergedOnly, when true, suppresses per-class proto and Schema Registry
+	// files. The merged message, its shared objects.proto dependency, and any
+	// configured prune sidecar are still emitted. Requires MergedMessage.
+	MergedOnly bool
 	// MergedSRSubject, when non-empty, annotates the merged message with the
 	// (redpanda.api.common.v1.schema_registry) option carrying this subject,
 	// so protoc-gen-go-sr-normalize generates the SR schema and subject
@@ -66,11 +70,19 @@ type Config struct {
 	// SRSchemaOutDir. Empty derives the name from the schema version's major
 	// component ("1.8.0" → "ocsfv1"). Only used when SRSchemaOutDir is set.
 	SRGoPackage string
+	// SRGoOnly, when true, writes only the generated <name>.sr.go schema
+	// embeds under SRSchemaOutDir and suppresses their intermediate
+	// <name>.sr.proto files. Requires SRSchemaOutDir.
+	SRGoOnly bool
 }
 
 // Generate loads the schema, emits the proto, writes --out and --tagmap.
 // Returns the stubbed object names (may be nil) and any error.
 func Generate(cfg Config) (stubbed []string, err error) {
+	if err := validateConfig(cfg); err != nil {
+		return nil, err
+	}
+
 	s, err := schema.LoadFile(cfg.SchemaPath)
 	if err != nil {
 		return nil, fmt.Errorf("load schema: %w", err)
@@ -115,7 +127,8 @@ func Generate(cfg Config) (stubbed []string, err error) {
 }
 
 // emitAll runs the per-class Emit plus, when cfg.MergedMessage is set, the
-// merged single-event EmitMerged, and combines the file lists.
+// merged single-event EmitMerged, and combines the file lists. With
+// cfg.MergedOnly, only EmitMerged runs.
 //
 // Both paths emit an identical objects.proto (same object closure, same tags
 // from the shared tagmap); the duplicate is dropped after an equality check so
@@ -140,9 +153,11 @@ func emitAll(s *schema.Schema, cfg Config, tm *tagmap.TagMap) (files []gen.Gener
 		fmt.Fprintf(os.Stderr, "iceberg-compat: pruned %d fields (see %s)\n", len(prunes), f.Path)
 	}
 
-	files, stubbed, err = gen.Emit(s, cfg.Classes, tm, cfg.Version)
-	if err != nil {
-		return nil, nil, fmt.Errorf("emit proto: %w", err)
+	if !cfg.MergedOnly {
+		files, stubbed, err = gen.Emit(s, cfg.Classes, tm, cfg.Version)
+		if err != nil {
+			return nil, nil, fmt.Errorf("emit proto: %w", err)
+		}
 	}
 
 	if strings.TrimSpace(cfg.MergedMessage) == "" {
@@ -160,6 +175,10 @@ func emitAll(s *schema.Schema, cfg Config, tm *tagmap.TagMap) (files []gen.Gener
 	mergedFiles, mergedStubbed, err := gen.EmitMerged(s, cfg.Classes, tm, cfg.Version, cfg.MergedMessage, cfg.MergedSRSubject)
 	if err != nil {
 		return nil, nil, fmt.Errorf("emit merged proto: %w", err)
+	}
+	if cfg.MergedOnly {
+		files, err = finishEmit(mergedFiles, sidecar, cfg)
+		return files, mergedStubbed, err
 	}
 	// Stub sets are identical by construction (same classes, same closure), so
 	// the per-class stub list already covers the merged run.
@@ -233,9 +252,13 @@ func checkMergedNameCollision(mergedMessage string, classes []string) error {
 // when cfg.MergedSRSubject is set), so consumers no longer hand-embed the
 // schema text.
 func emitAllSRSchemas(s *schema.Schema, cfg Config, tm *tagmap.TagMap) ([]gen.GeneratedFile, error) {
-	srFiles, err := gen.EmitSRSchemas(s, cfg.Classes, tm, cfg.Version)
-	if err != nil {
-		return nil, fmt.Errorf("emit sr schemas: %w", err)
+	var srFiles []gen.GeneratedFile
+	var err error
+	if !cfg.MergedOnly {
+		srFiles, err = gen.EmitSRSchemas(s, cfg.Classes, tm, cfg.Version)
+		if err != nil {
+			return nil, fmt.Errorf("emit sr schemas: %w", err)
+		}
 	}
 	// Map each SR schema to the message name whose constants embed it.
 	// Per-class files are named "<class>.sr.proto"; subjects only apply to
@@ -245,8 +268,10 @@ func emitAllSRSchemas(s *schema.Schema, cfg Config, tm *tagmap.TagMap) ([]gen.Ge
 		subject string
 	}
 	consts := make(map[string]srConst, len(cfg.Classes)+1)
-	for _, class := range cfg.Classes {
-		consts[class+".sr.proto"] = srConst{msgName: gen.ClassMessageName(class)}
+	if !cfg.MergedOnly {
+		for _, class := range cfg.Classes {
+			consts[class+".sr.proto"] = srConst{msgName: gen.ClassMessageName(class)}
+		}
 	}
 	if strings.TrimSpace(cfg.MergedMessage) != "" {
 		mergedSR, err := gen.EmitMergedSRSchema(s, cfg.Classes, tm, cfg.Version, cfg.MergedMessage)
@@ -277,6 +302,9 @@ func emitAllSRSchemas(s *schema.Schema, cfg Config, tm *tagmap.TagMap) ([]gen.Ge
 		goFiles = append(goFiles, goFile)
 	}
 	srFiles = append(srFiles, goFiles...)
+	if cfg.SRGoOnly {
+		srFiles = goFiles
+	}
 
 	sort.Slice(srFiles, func(i, j int) bool { return srFiles[i].Path < srFiles[j].Path })
 	if cfg.IcebergCompat {
@@ -311,6 +339,10 @@ func writeFiles(outDir string, files []gen.GeneratedFile) error {
 //     removed, or its content changed)
 //   - a new stubbed object appears (indicates schema regression)
 func Check(cfg Config) error {
+	if err := validateConfig(cfg); err != nil {
+		return err
+	}
+
 	s, err := schema.LoadFile(cfg.SchemaPath)
 	if err != nil {
 		return fmt.Errorf("load schema: %w", err)
@@ -379,6 +411,16 @@ func Check(cfg Config) error {
 		}
 	}
 
+	return nil
+}
+
+func validateConfig(cfg Config) error {
+	if cfg.MergedOnly && strings.TrimSpace(cfg.MergedMessage) == "" {
+		return errors.New("--merged-only requires --merged-message")
+	}
+	if cfg.SRGoOnly && strings.TrimSpace(cfg.SRSchemaOutDir) == "" {
+		return errors.New("--sr-go-only requires --sr-schema-out")
+	}
 	return nil
 }
 

--- a/ocsf/cmd/ocsf-protogen/protogen/protogen.go
+++ b/ocsf/cmd/ocsf-protogen/protogen/protogen.go
@@ -15,6 +15,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -113,7 +114,10 @@ func Generate(cfg Config) (stubbed []string, err error) {
 		return nil, err
 	}
 
-	if err := writeFiles(cfg.OutDir, files); err != nil {
+	// syncFiles, not writeFiles: a run that produces fewer artifacts than the last
+	// one must clear the difference, or switching to a narrower layout leaves
+	// strays that --check then rejects with no way to regenerate them away.
+	if err := syncFiles(cfg.OutDir, files, gen.IsManagedOutputArtifact); err != nil {
 		return nil, err
 	}
 
@@ -125,7 +129,7 @@ func Generate(cfg Config) (stubbed []string, err error) {
 		if err != nil {
 			return nil, err
 		}
-		if err := writeFiles(cfg.SRSchemaOutDir, srFiles); err != nil {
+		if err := syncFiles(cfg.SRSchemaOutDir, srFiles, gen.IsManagedSRArtifact); err != nil {
 			return nil, err
 		}
 	}
@@ -416,6 +420,58 @@ func writeFiles(outDir string, files []gen.GeneratedFile) error {
 	return nil
 }
 
+// syncFiles writes files under root and then removes generator-managed artifacts
+// in the same directories that this run no longer produces.
+//
+// Without the removal step, narrowing the output (--merged-only, --sr-go-only,
+// --mask-file) leaves the previous layout's files on disk: --check reports them
+// as strays, and its advice to "regenerate without --check" cannot clear them.
+// Reconciling makes broad -> narrow the ordinary regenerate-and-commit flow.
+//
+// Deletion is confined to the directories the generator writes into AND to names
+// the managed predicate claims, so unrelated committed files in the tree
+// (buf.yaml, buf.lock, the tagmap) are never candidates.
+func syncFiles(root string, files []gen.GeneratedFile, managed func(base string) bool) error {
+	if err := writeFiles(root, files); err != nil {
+		return err
+	}
+
+	want := make(map[string]struct{}, len(files))
+	dirs := make(map[string]struct{})
+	for _, f := range files {
+		want[f.Path] = struct{}{}
+		dirs[path.Dir(f.Path)] = struct{}{}
+	}
+
+	for dir := range dirs {
+		abs := filepath.Join(root, filepath.FromSlash(dir))
+		entries, err := os.ReadDir(abs)
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("read output dir %q: %w", abs, err)
+		}
+		for _, e := range entries {
+			if e.IsDir() || !managed(e.Name()) {
+				continue
+			}
+			rel := e.Name()
+			if dir != "." {
+				rel = dir + "/" + e.Name()
+			}
+			if _, produced := want[rel]; produced {
+				continue
+			}
+			if err := os.Remove(filepath.Join(abs, e.Name())); err != nil {
+				return fmt.Errorf("remove stale generated file %q: %w", rel, err)
+			}
+			fmt.Fprintf(os.Stderr, "removed stale generated file %s\n", rel)
+		}
+	}
+	return nil
+}
+
 // Check regenerates the proto tree in memory and detects drift vs. the committed
 // baseline tree rooted at OutDir (and the committed --tagmap). It returns a
 // non-nil error with a descriptive message when:
@@ -589,8 +645,10 @@ func readCommittedTree(outDir string, files []gen.GeneratedFile) (map[string]str
 		}
 	}
 
-	// Also enumerate committed .proto files under each versioned dir the
-	// generator writes into, so we catch files that should have been removed.
+	// Also enumerate every committed generator-managed artifact under each
+	// versioned dir the generator writes into, so we catch files that should have
+	// been removed. This covers the sidecars as well as the protos: dropping
+	// --mask-file or --iceberg-compat must not leave a stale report behind.
 	dirs := make(map[string]struct{})
 	for _, f := range files {
 		dirs[filepath.Dir(f.Path)] = struct{}{}
@@ -605,7 +663,7 @@ func readCommittedTree(outDir string, files []gen.GeneratedFile) (map[string]str
 			return nil, fmt.Errorf("read committed dir %q: %w", root, err)
 		}
 		for _, e := range entries {
-			if e.IsDir() || filepath.Ext(e.Name()) != ".proto" {
+			if e.IsDir() || !gen.IsManagedOutputArtifact(e.Name()) {
 				continue
 			}
 			rel := d + "/" + e.Name()

--- a/ocsf/cmd/ocsf-protogen/protogen/protogen.go
+++ b/ocsf/cmd/ocsf-protogen/protogen/protogen.go
@@ -149,7 +149,15 @@ func Generate(cfg Config) (stubbed []string, err error) {
 // model in place first — the caller-visible *schema.Schema mutates, so a later
 // emitAllSRSchemas call on the same instance emits the same shape — and the
 // corresponding sidecar files are appended to the returned file list.
+//
+// Tags are reserved over the UNMASKED, UNPRUNED model before that, so field
+// numbers never depend on what the mask or prune chose to emit (see
+// gen.ReserveTags).
 func emitAll(s *schema.Schema, cfg Config, tm *tagmap.TagMap) (files []gen.GeneratedFile, stubbed []string, err error) {
+	if err := gen.ReserveTags(s, cfg.Classes, cfg.MergedMessage, tm); err != nil {
+		return nil, nil, err
+	}
+
 	sidecars, err := narrowModel(s, cfg)
 	if err != nil {
 		return nil, nil, err

--- a/ocsf/cmd/ocsf-protogen/protogen/protogen.go
+++ b/ocsf/cmd/ocsf-protogen/protogen/protogen.go
@@ -74,6 +74,17 @@ type Config struct {
 	// embeds under SRSchemaOutDir and suppresses their intermediate
 	// <name>.sr.proto files. Requires SRSchemaOutDir.
 	SRGoOnly bool
+	// MaskPath, when non-empty, is the path to a read-mask YAML file listing
+	// the root-relative attribute paths to keep. Everything else is dropped
+	// from the model BEFORE any emission, so the per-class protos, the merged
+	// message, the SR schemas and the validation rules all describe the same
+	// narrowed contract. A sidecar (ocsf/v<N>/read-mask-report.txt) records the
+	// resolved keep set. Empty emits the full schema (today's behaviour).
+	//
+	// The mask is generator policy, not generator knowledge: which fields a
+	// consumer publishes lives in the consumer's repo next to its committed
+	// output, the same way --classes and --merged-message do.
+	MaskPath string
 }
 
 // Generate loads the schema, emits the proto, writes --out and --tagmap.
@@ -134,23 +145,14 @@ func Generate(cfg Config) (stubbed []string, err error) {
 // from the shared tagmap); the duplicate is dropped after an equality check so
 // a divergence surfaces as an error instead of a silent overwrite.
 //
-// When cfg.IcebergCompat is set, the schema model is pruned in place first —
-// the caller-visible *schema.Schema mutates, so a later emitAllSRSchemas call
-// on the same instance emits the same pruned shape — and the prune sidecar
-// file is appended to the returned file list.
+// When cfg.MaskPath or cfg.IcebergCompat is set, narrowModel shrinks the schema
+// model in place first — the caller-visible *schema.Schema mutates, so a later
+// emitAllSRSchemas call on the same instance emits the same shape — and the
+// corresponding sidecar files are appended to the returned file list.
 func emitAll(s *schema.Schema, cfg Config, tm *tagmap.TagMap) (files []gen.GeneratedFile, stubbed []string, err error) {
-	var sidecar *gen.GeneratedFile
-	if cfg.IcebergCompat {
-		prunes, pruneErr := gen.PruneForIceberg(s, cfg.Classes)
-		if pruneErr != nil {
-			return nil, nil, fmt.Errorf("iceberg-compat prune: %w", pruneErr)
-		}
-		f, sidecarErr := gen.PruneSidecarFile(cfg.Version, prunes)
-		if sidecarErr != nil {
-			return nil, nil, fmt.Errorf("iceberg-compat sidecar: %w", sidecarErr)
-		}
-		sidecar = &f
-		fmt.Fprintf(os.Stderr, "iceberg-compat: pruned %d fields (see %s)\n", len(prunes), f.Path)
+	sidecars, err := narrowModel(s, cfg)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	if !cfg.MergedOnly {
@@ -164,7 +166,7 @@ func emitAll(s *schema.Schema, cfg Config, tm *tagmap.TagMap) (files []gen.Gener
 		if strings.TrimSpace(cfg.MergedSRSubject) != "" {
 			return nil, nil, errors.New("--merged-sr-subject requires --merged-message")
 		}
-		files, err = finishEmit(files, sidecar, cfg)
+		files, err = finishEmit(files, sidecars, cfg)
 		return files, stubbed, err
 	}
 
@@ -177,7 +179,7 @@ func emitAll(s *schema.Schema, cfg Config, tm *tagmap.TagMap) (files []gen.Gener
 		return nil, nil, fmt.Errorf("emit merged proto: %w", err)
 	}
 	if cfg.MergedOnly {
-		files, err = finishEmit(mergedFiles, sidecar, cfg)
+		files, err = finishEmit(mergedFiles, sidecars, cfg)
 		return files, mergedStubbed, err
 	}
 	// Stub sets are identical by construction (same classes, same closure), so
@@ -198,16 +200,14 @@ func emitAll(s *schema.Schema, cfg Config, tm *tagmap.TagMap) (files []gen.Gener
 			return nil, nil, fmt.Errorf("merged emission produced %q with different content than per-class emission", f.Path)
 		}
 	}
-	files, err = finishEmit(files, sidecar, cfg)
+	files, err = finishEmit(files, sidecars, cfg)
 	return files, stubbed, err
 }
 
-// finishEmit appends the iceberg-compat sidecar (when present), sorts the file
-// list, and runs the iceberg-compat post-condition.
-func finishEmit(files []gen.GeneratedFile, sidecar *gen.GeneratedFile, cfg Config) ([]gen.GeneratedFile, error) {
-	if sidecar != nil {
-		files = append(files, *sidecar)
-	}
+// finishEmit appends the read-mask and iceberg-compat sidecars (whichever are
+// present), sorts the file list, and runs the iceberg-compat post-condition.
+func finishEmit(files []gen.GeneratedFile, sidecars []gen.GeneratedFile, cfg Config) ([]gen.GeneratedFile, error) {
+	files = append(files, sidecars...)
 	sort.Slice(files, func(i, j int) bool { return files[i].Path < files[j].Path })
 	if cfg.IcebergCompat {
 		if err := assertNoStructImport(files); err != nil {
@@ -215,6 +215,83 @@ func finishEmit(files []gen.GeneratedFile, sidecar *gen.GeneratedFile, cfg Confi
 		}
 	}
 	return files, nil
+}
+
+// narrowModel applies the read mask and then the iceberg-compat prune, mutating
+// s in place, and returns their sidecar files in output order.
+//
+// The order matters: the prune rules react to the shape of the model (R3 demotes
+// an edge because a dotted path overflows 63 chars, R4 drops edges to emptied
+// types), so masking first means the deep subtrees that force those demotions
+// are already gone and the surviving fields stay typed instead of collapsing to
+// JSON strings.
+func narrowModel(s *schema.Schema, cfg Config) ([]gen.GeneratedFile, error) {
+	var sidecars []gen.GeneratedFile
+
+	if strings.TrimSpace(cfg.MaskPath) != "" {
+		f, err := applyMask(s, cfg)
+		if err != nil {
+			return nil, err
+		}
+		sidecars = append(sidecars, f)
+	}
+
+	if cfg.IcebergCompat {
+		prunes, err := gen.PruneForIceberg(s, cfg.Classes)
+		if err != nil {
+			return nil, fmt.Errorf("iceberg-compat prune: %w", err)
+		}
+		f, err := gen.PruneSidecarFile(cfg.Version, prunes)
+		if err != nil {
+			return nil, fmt.Errorf("iceberg-compat sidecar: %w", err)
+		}
+		sidecars = append(sidecars, f)
+		fmt.Fprintf(os.Stderr, "iceberg-compat: pruned %d fields (see %s)\n", len(prunes), f.Path)
+	}
+
+	return sidecars, nil
+}
+
+// applyMask loads cfg.MaskPath, narrows the schema model to the fields it names,
+// and returns the report sidecar.
+//
+// When a merged message is being emitted the class discriminators must survive,
+// or the merged emitter produces CEL referencing fields that no longer exist —
+// checked here rather than left to fail at protovalidate compile time.
+func applyMask(s *schema.Schema, cfg Config) (gen.GeneratedFile, error) {
+	data, err := os.ReadFile(filepath.Clean(cfg.MaskPath))
+	if err != nil {
+		return gen.GeneratedFile{}, fmt.Errorf("read mask file %q: %w", cfg.MaskPath, err)
+	}
+	mask, err := gen.ParseMask(data)
+	if err != nil {
+		return gen.GeneratedFile{}, fmt.Errorf("mask file %q: %w", cfg.MaskPath, err)
+	}
+
+	res, err := gen.MaskFields(s, cfg.Classes, mask)
+	if err != nil {
+		return gen.GeneratedFile{}, fmt.Errorf("apply mask %q: %w", cfg.MaskPath, err)
+	}
+	if strings.TrimSpace(cfg.MergedMessage) != "" {
+		if err := gen.VerifyMergedDiscriminators(s, cfg.Classes); err != nil {
+			return gen.GeneratedFile{}, err
+		}
+	}
+
+	f, err := gen.MaskReportFile(cfg.Version, res)
+	if err != nil {
+		return gen.GeneratedFile{}, fmt.Errorf("mask report: %w", err)
+	}
+	fmt.Fprintf(os.Stderr,
+		"read-mask: kept %d fields; leaf columns %d -> %d, message types %d -> %d (see %s)\n",
+		len(res.Kept), res.Stats.LeafPathsBefore, res.Stats.LeafPathsAfter,
+		res.Stats.MessagesBefore, res.Stats.MessagesAfter, f.Path)
+	if len(res.Widened) > 0 {
+		fmt.Fprintf(os.Stderr,
+			"read-mask: %d leaf columns kept that no mask path asked for (shared types); see the report\n",
+			len(res.Widened))
+	}
+	return f, nil
 }
 
 // assertNoStructImport is a belt-and-braces post-condition for

--- a/ocsf/cmd/ocsf-protogen/protogen/protogen_test.go
+++ b/ocsf/cmd/ocsf-protogen/protogen/protogen_test.go
@@ -1324,3 +1324,160 @@ func TestMaskFromScratchTagmapMatchesUnmasked(t *testing.T) {
 	require.NoError(t, tagmap.CheckCompat(full, scratch))
 	require.NoError(t, tagmap.CheckCompat(scratch, full))
 }
+
+// TestGenerateBroadToNarrowRemovesStrays is the adoption path this reconciliation
+// exists for: an existing full baseline switched to the narrower layout. Before
+// syncFiles the per-class artifacts stayed on disk and --check then rejected them
+// as strays, with its own advice ("regenerate without --check") unable to clear
+// them.
+func TestGenerateBroadToNarrowRemovesStrays(t *testing.T) {
+	dir := t.TempDir()
+	srDir := t.TempDir()
+
+	broad := protogen.Config{
+		SchemaPath:     schemaFixture(),
+		Classes:        []string{"api_activity", "entity_management"},
+		Version:        "1.8.0",
+		OutDir:         dir,
+		TagmapPath:     filepath.Join(dir, "field-numbers.json"),
+		SRSchemaOutDir: srDir,
+		MergedMessage:  "AuditEvent",
+	}
+	_, err := protogen.Generate(broad)
+	require.NoError(t, err)
+	require.FileExists(t, filepath.Join(dir, "ocsf", "v1", "api_activity.proto"))
+	require.FileExists(t, filepath.Join(srDir, "api_activity.sr.proto"))
+
+	narrow := broad
+	narrow.MergedOnly = true
+	narrow.SRGoOnly = true
+	_, err = protogen.Generate(narrow)
+	require.NoError(t, err)
+
+	// The previous layout's artifacts are gone...
+	for _, p := range []string{"api_activity.proto", "entity_management.proto"} {
+		require.NoFileExists(t, filepath.Join(dir, "ocsf", "v1", p))
+	}
+	for _, p := range []string{
+		"api_activity.sr.proto", "api_activity.sr.go",
+		"entity_management.sr.proto", "entity_management.sr.go",
+		"audit_event.sr.proto",
+	} {
+		require.NoFileExists(t, filepath.Join(srDir, p))
+	}
+	// ...and the narrow layout's are present.
+	require.FileExists(t, filepath.Join(dir, "ocsf", "v1", "audit_event.proto"))
+	require.FileExists(t, filepath.Join(dir, "ocsf", "v1", "objects.proto"))
+	require.FileExists(t, filepath.Join(srDir, "audit_event.sr.go"))
+
+	checkCfg := narrow
+	checkCfg.Check = true
+	require.NoError(t, protogen.Check(checkCfg),
+		"--check must pass right after the broad -> narrow regeneration")
+}
+
+// TestGenerateDroppingMaskClearsReport verifies the sidecars reconcile too:
+// removing --mask-file must not leave a stale read-mask-report.txt describing a
+// mask that is no longer applied.
+func TestGenerateDroppingMaskClearsReport(t *testing.T) {
+	dir := t.TempDir()
+	report := filepath.Join(dir, "ocsf", "v1", "read-mask-report.txt")
+
+	masked := protogen.Config{
+		SchemaPath:    schemaFixture(),
+		Classes:       []string{"api_activity", "entity_management"},
+		Version:       "1.8.0",
+		OutDir:        dir,
+		TagmapPath:    filepath.Join(dir, "field-numbers.json"),
+		MergedMessage: "AuditEvent",
+		MaskPath:      writeMask(t, dir, cloudMaskYAML),
+	}
+	_, err := protogen.Generate(masked)
+	require.NoError(t, err)
+	require.FileExists(t, report)
+
+	unmasked := masked
+	unmasked.MaskPath = ""
+	_, err = protogen.Generate(unmasked)
+	require.NoError(t, err)
+	require.NoFileExists(t, report, "the stale mask report must be removed")
+
+	checkCfg := unmasked
+	checkCfg.Check = true
+	require.NoError(t, protogen.Check(checkCfg))
+}
+
+// TestCheckDetectsStaleSidecar verifies check mode enumerates managed sidecars,
+// not just .proto files — otherwise a stale report committed by hand (or left by
+// an older generator) passes silently.
+func TestCheckDetectsStaleSidecar(t *testing.T) {
+	dir := t.TempDir()
+	cfg := protogen.Config{
+		SchemaPath:    schemaFixture(),
+		Classes:       []string{"api_activity"},
+		Version:       "1.8.0",
+		OutDir:        dir,
+		TagmapPath:    filepath.Join(dir, "field-numbers.json"),
+		MergedMessage: "AuditEvent",
+	}
+	_, err := protogen.Generate(cfg)
+	require.NoError(t, err)
+
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "ocsf", "v1", "read-mask-report.txt"), []byte("stale\n"), 0o600))
+
+	cfg.Check = true
+	err = protogen.Check(cfg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "read-mask-report.txt")
+}
+
+// TestSyncFilesLeavesUnmanagedFilesAlone is the safety net on a destructive
+// operation: reconciliation may only delete files whose names the generator
+// claims, in the directories it writes to. Committed module files and anything
+// hand-added must survive.
+func TestSyncFilesLeavesUnmanagedFilesAlone(t *testing.T) {
+	dir := t.TempDir()
+	srDir := t.TempDir()
+	tagmapPath := filepath.Join(dir, "field-numbers.json")
+
+	cfg := protogen.Config{
+		SchemaPath:     schemaFixture(),
+		Classes:        []string{"api_activity", "entity_management"},
+		Version:        "1.8.0",
+		OutDir:         dir,
+		TagmapPath:     tagmapPath,
+		SRSchemaOutDir: srDir,
+		MergedMessage:  "AuditEvent",
+	}
+	_, err := protogen.Generate(cfg)
+	require.NoError(t, err)
+
+	// Files the generator must never touch: module config at the out root, a
+	// hand-added note inside the versioned dir, and a non-generated Go file in the
+	// flat SR dir.
+	bystanders := map[string]string{
+		filepath.Join(dir, "buf.yaml"):               "version: v2\n",
+		filepath.Join(dir, "buf.lock"):               "# lock\n",
+		filepath.Join(dir, "ocsf", "v1", "NOTES.md"): "hand written\n",
+		filepath.Join(srDir, "doc.go"):               "package schema\n",
+		filepath.Join(srDir, "helper_extra.go.txt"):  "not generated\n",
+	}
+	for p, content := range bystanders {
+		require.NoError(t, os.WriteFile(p, []byte(content), 0o600))
+	}
+
+	// Regenerate narrower, which triggers reconciliation in both directories.
+	narrow := cfg
+	narrow.MergedOnly = true
+	narrow.SRGoOnly = true
+	_, err = protogen.Generate(narrow)
+	require.NoError(t, err)
+
+	for p, content := range bystanders {
+		got, err := os.ReadFile(p)
+		require.NoErrorf(t, err, "reconciliation deleted %q", p)
+		require.Equal(t, content, string(got), "reconciliation modified %q", p)
+	}
+	require.FileExists(t, tagmapPath, "the tagmap must never be reconciled away")
+}

--- a/ocsf/cmd/ocsf-protogen/protogen/protogen_test.go
+++ b/ocsf/cmd/ocsf-protogen/protogen/protogen_test.go
@@ -452,7 +452,6 @@ func TestGenerateMergedOnlyThenCheck(t *testing.T) {
 		MergedMessage:   "AuditEvent",
 		MergedOnly:      true,
 		MergedSRSubject: "redpanda.ocsf.audit-events-value",
-		SRGoOnly:        true,
 	}
 
 	_, err := protogen.Generate(cfg)
@@ -464,7 +463,7 @@ func TestGenerateMergedOnlyThenCheck(t *testing.T) {
 	require.NoFileExists(t, filepath.Join(dir, "ocsf", "v1", "entity_management.proto"))
 
 	require.FileExists(t, filepath.Join(srDir, "audit_event.sr.go"))
-	require.NoFileExists(t, filepath.Join(srDir, "audit_event.sr.proto"))
+	require.FileExists(t, filepath.Join(srDir, "audit_event.sr.proto"))
 	require.NoFileExists(t, filepath.Join(srDir, "api_activity.sr.proto"))
 	require.NoFileExists(t, filepath.Join(srDir, "api_activity.sr.go"))
 	require.NoFileExists(t, filepath.Join(srDir, "entity_management.sr.proto"))
@@ -916,61 +915,6 @@ func TestGenerateSRGoPackageOverride(t *testing.T) {
 	require.Contains(t, string(classGo), "package auditschema\n")
 }
 
-// TestGenerateSRGoOnly verifies consumers can commit the Go schema embeds
-// without also retaining their intermediate .sr.proto inputs.
-func TestGenerateSRGoOnly(t *testing.T) {
-	dir := t.TempDir()
-	srDir := t.TempDir()
-
-	cfg := protogen.Config{
-		SchemaPath:      schemaFixture(),
-		Classes:         []string{"api_activity", "entity_management"},
-		Version:         "1.8.0",
-		OutDir:          dir,
-		TagmapPath:      filepath.Join(dir, "field-numbers.json"),
-		SRSchemaOutDir:  srDir,
-		MergedMessage:   "AuditEvent",
-		MergedSRSubject: "redpanda.ocsf.audit-events-value",
-		SRGoOnly:        true,
-	}
-
-	_, err := protogen.Generate(cfg)
-	require.NoError(t, err)
-
-	for _, name := range []string{
-		"api_activity.sr.go",
-		"entity_management.sr.go",
-		"audit_event.sr.go",
-	} {
-		require.FileExists(t, filepath.Join(srDir, name))
-	}
-	for _, name := range []string{
-		"api_activity.sr.proto",
-		"entity_management.sr.proto",
-		"audit_event.sr.proto",
-	} {
-		require.NoFileExists(t, filepath.Join(srDir, name))
-	}
-
-	checkCfg := cfg
-	checkCfg.Check = true
-	require.NoError(t, protogen.Check(checkCfg))
-}
-
-func TestGenerateSRGoOnlyRequiresSchemaOut(t *testing.T) {
-	cfg := protogen.Config{
-		SchemaPath: schemaFixture(),
-		Classes:    []string{"api_activity"},
-		Version:    "1.8.0",
-		OutDir:     t.TempDir(),
-		TagmapPath: filepath.Join(t.TempDir(), "field-numbers.json"),
-		SRGoOnly:   true,
-	}
-
-	_, err := protogen.Generate(cfg)
-	require.ErrorContains(t, err, "--sr-go-only requires --sr-schema-out")
-}
-
 // TestCheckFailsOnStraySRGo verifies --check detects a committed *.sr.go the
 // generator no longer produces.
 func TestCheckFailsOnStraySRGo(t *testing.T) {
@@ -1084,7 +1028,6 @@ func TestGenerateWithMaskThenCheck(t *testing.T) {
 		MergedMessage:   "AuditEvent",
 		MergedOnly:      true,
 		MergedSRSubject: "redpanda.ocsf.audit-events-value",
-		SRGoOnly:        true,
 		IcebergCompat:   true,
 		MaskPath:        writeMask(t, dir, cloudMaskYAML),
 	}
@@ -1350,7 +1293,6 @@ func TestGenerateBroadToNarrowRemovesStrays(t *testing.T) {
 
 	narrow := broad
 	narrow.MergedOnly = true
-	narrow.SRGoOnly = true
 	_, err = protogen.Generate(narrow)
 	require.NoError(t, err)
 
@@ -1361,14 +1303,15 @@ func TestGenerateBroadToNarrowRemovesStrays(t *testing.T) {
 	for _, p := range []string{
 		"api_activity.sr.proto", "api_activity.sr.go",
 		"entity_management.sr.proto", "entity_management.sr.go",
-		"audit_event.sr.proto",
 	} {
 		require.NoFileExists(t, filepath.Join(srDir, p))
 	}
-	// ...and the narrow layout's are present.
+	// ...and the narrow layout's are present. --merged-only suppresses the
+	// per-class SR artifacts but keeps the merged pair.
 	require.FileExists(t, filepath.Join(dir, "ocsf", "v1", "audit_event.proto"))
 	require.FileExists(t, filepath.Join(dir, "ocsf", "v1", "objects.proto"))
 	require.FileExists(t, filepath.Join(srDir, "audit_event.sr.go"))
+	require.FileExists(t, filepath.Join(srDir, "audit_event.sr.proto"))
 
 	checkCfg := narrow
 	checkCfg.Check = true
@@ -1470,7 +1413,6 @@ func TestSyncFilesLeavesUnmanagedFilesAlone(t *testing.T) {
 	// Regenerate narrower, which triggers reconciliation in both directories.
 	narrow := cfg
 	narrow.MergedOnly = true
-	narrow.SRGoOnly = true
 	_, err = protogen.Generate(narrow)
 	require.NoError(t, err)
 

--- a/ocsf/cmd/ocsf-protogen/protogen/protogen_test.go
+++ b/ocsf/cmd/ocsf-protogen/protogen/protogen_test.go
@@ -1261,13 +1261,20 @@ func TestGenerateWithMissingMaskFile(t *testing.T) {
 	require.ErrorContains(t, err, "read mask file")
 }
 
-// TestMaskFromScratchTagmapRenumbers pins the sharp edge the README warns about:
-// the tagmap is what carries an excluded field's number, so bootstrapping a fresh
-// tagmap under a mask assigns the survivors compact numbers instead of their
-// original ones. It is not a bug — there is nothing to preserve — but it means a
-// tagmap must never be regenerated from scratch once a mask exists, and
-// --compat-check is the gate that catches it.
-func TestMaskFromScratchTagmapRenumbers(t *testing.T) {
+// TestMaskFromScratchTagmapMatchesUnmasked is the guarantee gen.ReserveTags
+// exists to provide: field numbers are a function of the OCSF schema and the
+// class selection alone, never of what the mask chose to emit. A tagmap
+// bootstrapped with a mask active must therefore be identical to one
+// bootstrapped without it.
+//
+// Before ReserveTags this was false and silently so: every one of the 20
+// surviving AuditEvent fields moved (actor 7 -> 3, time 61 -> 19), which would
+// decode every previously written record to an empty event.
+//
+// It also pins the coupling ReserveTags introduces — it must walk the same
+// messages and the same within-message order as the emitters, so this test fails
+// if the two ever drift apart.
+func TestMaskFromScratchTagmapMatchesUnmasked(t *testing.T) {
 	base := func(dir, maskPath string) protogen.Config {
 		return protogen.Config{
 			SchemaPath:    schemaFixture(),
@@ -1293,19 +1300,27 @@ func TestMaskFromScratchTagmapRenumbers(t *testing.T) {
 	scratch, err := tagmap.Load(filepath.Join(scratchDir, "field-numbers.json"))
 	require.NoError(t, err)
 
-	// The survivors got compacted numbers, so at least one moved.
-	moved := false
-	for _, attr := range []string{"actor", "api", "metadata", "time", "type_uid"} {
-		want, ok := full.Tag("ApiActivity", attr)
-		require.True(t, ok)
-		got, ok := scratch.Tag("ApiActivity", attr)
-		require.True(t, ok)
-		if want != got {
-			moved = true
-		}
-	}
-	require.True(t, moved, "a from-scratch masked tagmap compacts field numbers")
+	// The strongest form of the guarantee: the two bootstrapped tagmaps are the
+	// same file. Not just the surviving fields — the excluded ones too, since
+	// those are what let the mask be widened later without renumbering.
+	fullJSON, err := os.ReadFile(filepath.Join(fullDir, "field-numbers.json"))
+	require.NoError(t, err)
+	scratchJSON, err := os.ReadFile(filepath.Join(scratchDir, "field-numbers.json"))
+	require.NoError(t, err)
+	require.Equal(t, string(fullJSON), string(scratchJSON),
+		"a tagmap bootstrapped with a mask must be identical to one bootstrapped without it")
 
-	require.Error(t, tagmap.CheckCompat(full, scratch),
-		"--compat-check must reject a from-scratch masked tagmap against the full baseline")
+	// Spot-check the numbers that used to move, so a failure names them.
+	for _, attr := range []string{"actor", "api", "metadata", "time", "type_uid"} {
+		want, ok := full.Tag("AuditEvent", attr)
+		require.True(t, ok)
+		got, ok := scratch.Tag("AuditEvent", attr)
+		require.True(t, ok)
+		require.Equalf(t, want, got, "AuditEvent.%s renumbered under the mask", attr)
+	}
+
+	// Interchangeable in both directions — a from-scratch masked bootstrap is no
+	// longer destructive.
+	require.NoError(t, tagmap.CheckCompat(full, scratch))
+	require.NoError(t, tagmap.CheckCompat(scratch, full))
 }

--- a/ocsf/cmd/ocsf-protogen/protogen/protogen_test.go
+++ b/ocsf/cmd/ocsf-protogen/protogen/protogen_test.go
@@ -998,3 +998,314 @@ func TestCheckFailsOnStraySRGo(t *testing.T) {
 	require.Error(t, err, "--check must fail on a stray committed .sr.go")
 	require.Contains(t, err.Error(), "dropped_class.sr.go")
 }
+
+// cloudMaskYAML is a read mask close to what a real single-topic audit-log
+// consumer publishes: the fields it actually populates, and nothing else. It
+// doubles as the fixture proving the mask scales down the real OCSF schema, not
+// just a synthetic one.
+const cloudMaskYAML = `version: 1
+paths:
+  - action_id
+  - activity_id
+  - actor.app_name
+  - actor.app_uid
+  - actor.invoked_by
+  - actor.user.email_addr
+  - actor.user.name
+  - api.operation
+  - api.request.data
+  - api.request.flags
+  - api.response.code
+  - api.response.data
+  - api.response.error
+  - api.response.flags
+  - api.service.name
+  - authorizations.decision
+  - authorizations.policy.is_applied
+  - authorizations.policy.name
+  - authorizations.policy.uid
+  - category_uid
+  - class_uid
+  - disposition_id
+  - entity.data
+  - entity.name
+  - entity.type
+  - entity.uid
+  - entity_result.data
+  - entity_result.name
+  - entity_result.type
+  - entity_result.uid
+  - message
+  - metadata.product.feature.name
+  - metadata.product.name
+  - metadata.product.vendor_name
+  - metadata.profiles
+  - metadata.tenant_uid
+  - metadata.uid
+  - metadata.version
+  - policy.is_applied
+  - policy.name
+  - policy.uid
+  - resources.name
+  - resources.type
+  - resources.uid
+  - severity_id
+  - src_endpoint.ip
+  - src_endpoint.svc_name
+  - status_detail
+  - status_id
+  - time
+  - type_uid
+`
+
+// writeMask writes a mask file into dir and returns its path.
+func writeMask(t *testing.T, dir, body string) string {
+	t.Helper()
+	path := filepath.Join(dir, "read-mask.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(body), 0o600))
+	return path
+}
+
+// TestGenerateWithMaskThenCheck is the end-to-end case against the real OCSF
+// schema: a mask of the fields a consumer publishes collapses the emitted model
+// by nearly two orders of magnitude, the report sidecar records it, and --check
+// round-trips on the masked baseline.
+func TestGenerateWithMaskThenCheck(t *testing.T) {
+	dir := t.TempDir()
+	srDir := t.TempDir()
+
+	cfg := protogen.Config{
+		SchemaPath:      schemaFixture(),
+		Classes:         []string{"api_activity", "entity_management"},
+		Version:         "1.8.0",
+		OutDir:          dir,
+		TagmapPath:      filepath.Join(dir, "field-numbers.json"),
+		SRSchemaOutDir:  srDir,
+		MergedMessage:   "AuditEvent",
+		MergedOnly:      true,
+		MergedSRSubject: "redpanda.ocsf.audit-events-value",
+		SRGoOnly:        true,
+		IcebergCompat:   true,
+		MaskPath:        writeMask(t, dir, cloudMaskYAML),
+	}
+
+	_, err := protogen.Generate(cfg)
+	require.NoError(t, err)
+
+	// The keep set is reported against the class messages the mask resolves
+	// through; the merged AuditEvent is the union of those, so it has no keep
+	// entries of its own.
+	report, err := os.ReadFile(filepath.Join(dir, "ocsf", "v1", "read-mask-report.txt"))
+	require.NoError(t, err)
+	require.Contains(t, string(report), "leaf columns:")
+	require.Contains(t, string(report), "ApiActivity.actor")
+	require.Contains(t, string(report), "EntityManagement.entity_result")
+	require.Contains(t, string(report), "User.email_addr")
+	require.Contains(t, string(report), "# (none)", "this mask closes off every shared embedding")
+
+	// The masked schema must be dramatically smaller than the unmasked one, and
+	// must no longer carry the objects the mask closed off.
+	objects, err := os.ReadFile(filepath.Join(dir, "ocsf", "v1", "objects.proto"))
+	require.NoError(t, err)
+	require.Contains(t, string(objects), "message User {")
+	require.NotContains(t, string(objects), "message Osint ",
+		"osint is the single largest subtree and no mask path names it")
+	require.NotContains(t, string(objects), "message Malware ")
+	require.Less(t, strings.Count(string(objects), "\nmessage "), 30,
+		"the retained object closure should be a fraction of the ~100 messages OCSF reaches")
+
+	checkCfg := cfg
+	checkCfg.Check = true
+	require.NoError(t, protogen.Check(checkCfg),
+		"--check must pass immediately after Generate on the same masked baseline")
+}
+
+// TestMaskShrinksIcebergPrunes verifies the ordering payoff on the real schema:
+// masking first removes the deep subtrees that force R3 demotions, so far fewer
+// fields have to be collapsed into JSON strings to satisfy Iceberg/Oxla.
+func TestMaskShrinksIcebergPrunes(t *testing.T) {
+	countPrunes := func(t *testing.T, maskPath string) int {
+		t.Helper()
+		dir := t.TempDir()
+		cfg := protogen.Config{
+			SchemaPath:    schemaFixture(),
+			Classes:       []string{"api_activity", "entity_management"},
+			Version:       "1.8.0",
+			OutDir:        dir,
+			TagmapPath:    filepath.Join(dir, "field-numbers.json"),
+			MergedMessage: "AuditEvent",
+			IcebergCompat: true,
+			MaskPath:      maskPath,
+		}
+		_, err := protogen.Generate(cfg)
+		require.NoError(t, err)
+
+		body, err := os.ReadFile(filepath.Join(dir, "ocsf", "v1", "iceberg-compat-prunes.txt"))
+		require.NoError(t, err)
+		prunes := 0
+		for line := range strings.SplitSeq(string(body), "\n") {
+			if line != "" && !strings.HasPrefix(line, "#") {
+				prunes++
+			}
+		}
+		return prunes
+	}
+
+	unmasked := countPrunes(t, "")
+	masked := countPrunes(t, writeMask(t, t.TempDir(), cloudMaskYAML))
+
+	require.Positive(t, unmasked, "the full schema needs demotions to fit Iceberg")
+	require.Less(t, masked, unmasked/2,
+		"masking first should remove most of the fidelity loss (was %d prunes, now %d)", unmasked, masked)
+}
+
+// TestGenerateWithMaskPreservesFieldNumbers verifies the wire-stability
+// guarantee through the CLI layer: masking an existing baseline neither
+// renumbers the surviving fields nor shrinks the committed tagmap, so
+// --compat-check stays clean and the mask can be widened later for free.
+func TestGenerateWithMaskPreservesFieldNumbers(t *testing.T) {
+	dir := t.TempDir()
+	tagmapPath := filepath.Join(dir, "field-numbers.json")
+
+	base := protogen.Config{
+		SchemaPath:    schemaFixture(),
+		Classes:       []string{"api_activity", "entity_management"},
+		Version:       "1.8.0",
+		OutDir:        dir,
+		TagmapPath:    tagmapPath,
+		MergedMessage: "AuditEvent",
+		IcebergCompat: true,
+	}
+
+	// Generate unmasked first, so the tagmap holds every attribute.
+	_, err := protogen.Generate(base)
+	require.NoError(t, err)
+	unmasked, err := tagmap.Load(tagmapPath)
+	require.NoError(t, err)
+
+	// Now regenerate the same baseline with a mask.
+	masked := base
+	masked.OutDir = t.TempDir()
+	masked.MaskPath = writeMask(t, dir, cloudMaskYAML)
+	_, err = protogen.Generate(masked)
+	require.NoError(t, err)
+
+	after, err := tagmap.Load(tagmapPath)
+	require.NoError(t, err)
+	require.NoError(t, tagmap.CheckCompat(unmasked, after),
+		"masking must not renumber or drop tags — --compat-check runs exactly this")
+
+	for _, attr := range []string{"actor", "time", "osint", "malware"} {
+		want, ok := unmasked.Tag("AuditEvent", attr)
+		require.True(t, ok, "baseline assigned %q", attr)
+		got, ok := after.Tag("AuditEvent", attr)
+		require.True(t, ok, "masked run kept the tagmap entry for %q", attr)
+		require.Equal(t, want, got, "field number for %q must not move", attr)
+	}
+}
+
+// TestGenerateWithMaskRejectsDroppedDiscriminator verifies the merged emission's
+// hard dependency is enforced at generation time: without class_uid the merged
+// CEL would reference a field that no longer exists.
+func TestGenerateWithMaskRejectsDroppedDiscriminator(t *testing.T) {
+	dir := t.TempDir()
+
+	cfg := protogen.Config{
+		SchemaPath:    schemaFixture(),
+		Classes:       []string{"api_activity", "entity_management"},
+		Version:       "1.8.0",
+		OutDir:        dir,
+		TagmapPath:    filepath.Join(dir, "field-numbers.json"),
+		MergedMessage: "AuditEvent",
+		MaskPath:      writeMask(t, dir, "version: 1\npaths:\n  - time\n  - category_uid\n  - type_uid\n"),
+	}
+
+	_, err := protogen.Generate(cfg)
+	require.ErrorContains(t, err, `lost "class_uid"`)
+}
+
+// TestGenerateWithMaskUnresolvedPath verifies an allowlist entry that no longer
+// matches the schema fails generation. This is what stops an OCSF rename from
+// silently dropping a column consumers query.
+func TestGenerateWithMaskUnresolvedPath(t *testing.T) {
+	dir := t.TempDir()
+
+	cfg := protogen.Config{
+		SchemaPath: schemaFixture(),
+		Classes:    []string{"api_activity"},
+		Version:    "1.8.0",
+		OutDir:     dir,
+		TagmapPath: filepath.Join(dir, "field-numbers.json"),
+		MaskPath:   writeMask(t, dir, "version: 1\npaths:\n  - time\n  - actor.user.emial_addr\n"),
+	}
+
+	_, err := protogen.Generate(cfg)
+	require.ErrorContains(t, err, `has no attribute "emial_addr"`)
+}
+
+// TestGenerateWithMissingMaskFile verifies a bad --mask-file path fails loudly
+// rather than falling back to emitting the whole schema.
+func TestGenerateWithMissingMaskFile(t *testing.T) {
+	dir := t.TempDir()
+
+	cfg := protogen.Config{
+		SchemaPath: schemaFixture(),
+		Classes:    []string{"api_activity"},
+		Version:    "1.8.0",
+		OutDir:     dir,
+		TagmapPath: filepath.Join(dir, "field-numbers.json"),
+		MaskPath:   filepath.Join(dir, "does-not-exist.yaml"),
+	}
+
+	_, err := protogen.Generate(cfg)
+	require.ErrorContains(t, err, "read mask file")
+}
+
+// TestMaskFromScratchTagmapRenumbers pins the sharp edge the README warns about:
+// the tagmap is what carries an excluded field's number, so bootstrapping a fresh
+// tagmap under a mask assigns the survivors compact numbers instead of their
+// original ones. It is not a bug — there is nothing to preserve — but it means a
+// tagmap must never be regenerated from scratch once a mask exists, and
+// --compat-check is the gate that catches it.
+func TestMaskFromScratchTagmapRenumbers(t *testing.T) {
+	base := func(dir, maskPath string) protogen.Config {
+		return protogen.Config{
+			SchemaPath:    schemaFixture(),
+			Classes:       []string{"api_activity", "entity_management"},
+			Version:       "1.8.0",
+			OutDir:        dir,
+			TagmapPath:    filepath.Join(dir, "field-numbers.json"),
+			MergedMessage: "AuditEvent",
+			IcebergCompat: true,
+			MaskPath:      maskPath,
+		}
+	}
+
+	fullDir := t.TempDir()
+	_, err := protogen.Generate(base(fullDir, ""))
+	require.NoError(t, err)
+	full, err := tagmap.Load(filepath.Join(fullDir, "field-numbers.json"))
+	require.NoError(t, err)
+
+	scratchDir := t.TempDir()
+	_, err = protogen.Generate(base(scratchDir, writeMask(t, scratchDir, cloudMaskYAML)))
+	require.NoError(t, err)
+	scratch, err := tagmap.Load(filepath.Join(scratchDir, "field-numbers.json"))
+	require.NoError(t, err)
+
+	// The survivors got compacted numbers, so at least one moved.
+	moved := false
+	for _, attr := range []string{"actor", "api", "metadata", "time", "type_uid"} {
+		want, ok := full.Tag("ApiActivity", attr)
+		require.True(t, ok)
+		got, ok := scratch.Tag("ApiActivity", attr)
+		require.True(t, ok)
+		if want != got {
+			moved = true
+		}
+	}
+	require.True(t, moved, "a from-scratch masked tagmap compacts field numbers")
+
+	require.Error(t, tagmap.CheckCompat(full, scratch),
+		"--compat-check must reject a from-scratch masked tagmap against the full baseline")
+}

--- a/ocsf/cmd/ocsf-protogen/protogen/protogen_test.go
+++ b/ocsf/cmd/ocsf-protogen/protogen/protogen_test.go
@@ -434,6 +434,109 @@ func TestGenerateMergedThenCheck(t *testing.T) {
 		"--check must pass immediately after Generate on the same merged baseline")
 }
 
+// TestGenerateMergedOnlyThenCheck verifies MergedOnly suppresses every
+// per-class proto and SR artifact while retaining the merged message, its
+// shared objects dependency, and native --check support.
+func TestGenerateMergedOnlyThenCheck(t *testing.T) {
+	dir := t.TempDir()
+	srDir := t.TempDir()
+	tagmapPath := filepath.Join(dir, "field-numbers.json")
+
+	cfg := protogen.Config{
+		SchemaPath:      schemaFixture(),
+		Classes:         []string{"api_activity", "entity_management"},
+		Version:         "1.8.0",
+		OutDir:          dir,
+		TagmapPath:      tagmapPath,
+		SRSchemaOutDir:  srDir,
+		MergedMessage:   "AuditEvent",
+		MergedOnly:      true,
+		MergedSRSubject: "redpanda.ocsf.audit-events-value",
+		SRGoOnly:        true,
+	}
+
+	_, err := protogen.Generate(cfg)
+	require.NoError(t, err)
+
+	require.FileExists(t, filepath.Join(dir, "ocsf", "v1", "audit_event.proto"))
+	require.FileExists(t, filepath.Join(dir, "ocsf", "v1", "objects.proto"))
+	require.NoFileExists(t, filepath.Join(dir, "ocsf", "v1", "api_activity.proto"))
+	require.NoFileExists(t, filepath.Join(dir, "ocsf", "v1", "entity_management.proto"))
+
+	require.FileExists(t, filepath.Join(srDir, "audit_event.sr.go"))
+	require.NoFileExists(t, filepath.Join(srDir, "audit_event.sr.proto"))
+	require.NoFileExists(t, filepath.Join(srDir, "api_activity.sr.proto"))
+	require.NoFileExists(t, filepath.Join(srDir, "api_activity.sr.go"))
+	require.NoFileExists(t, filepath.Join(srDir, "entity_management.sr.proto"))
+	require.NoFileExists(t, filepath.Join(srDir, "entity_management.sr.go"))
+
+	checkCfg := cfg
+	checkCfg.Check = true
+	require.NoError(t, protogen.Check(checkCfg),
+		"--check must pass immediately after Generate on the same merged-only baseline")
+}
+
+// TestGenerateMergedOnlyMatchesMergedOutput verifies selecting only the merged
+// layout changes the file set, not the merged wire schema.
+func TestGenerateMergedOnlyMatchesMergedOutput(t *testing.T) {
+	full := protogen.Config{
+		SchemaPath:      schemaFixture(),
+		Classes:         []string{"api_activity", "entity_management"},
+		Version:         "1.8.0",
+		OutDir:          t.TempDir(),
+		SRSchemaOutDir:  t.TempDir(),
+		MergedMessage:   "AuditEvent",
+		MergedSRSubject: "redpanda.ocsf.audit-events-value",
+	}
+	full.TagmapPath = filepath.Join(full.OutDir, "field-numbers.json")
+
+	mergedOnly := full
+	mergedOnly.OutDir = t.TempDir()
+	mergedOnly.TagmapPath = filepath.Join(mergedOnly.OutDir, "field-numbers.json")
+	mergedOnly.SRSchemaOutDir = t.TempDir()
+	mergedOnly.MergedOnly = true
+
+	_, err := protogen.Generate(full)
+	require.NoError(t, err)
+	_, err = protogen.Generate(mergedOnly)
+	require.NoError(t, err)
+
+	for _, path := range []string{
+		"ocsf/v1/audit_event.proto",
+		"ocsf/v1/objects.proto",
+	} {
+		fullContent, err := os.ReadFile(filepath.Join(full.OutDir, filepath.FromSlash(path)))
+		require.NoError(t, err)
+		mergedOnlyContent, err := os.ReadFile(filepath.Join(mergedOnly.OutDir, filepath.FromSlash(path)))
+		require.NoError(t, err)
+		require.Equal(t, fullContent, mergedOnlyContent, "merged output differs for %s", path)
+	}
+	for _, name := range []string{"audit_event.sr.proto", "audit_event.sr.go"} {
+		fullContent, err := os.ReadFile(filepath.Join(full.SRSchemaOutDir, name))
+		require.NoError(t, err)
+		mergedOnlyContent, err := os.ReadFile(filepath.Join(mergedOnly.SRSchemaOutDir, name))
+		require.NoError(t, err)
+		require.Equal(t, fullContent, mergedOnlyContent, "merged SR output differs for %s", name)
+	}
+}
+
+// TestGenerateMergedOnlyRequiresMergedMessage verifies the selection cannot be
+// enabled without naming the merged message to emit.
+func TestGenerateMergedOnlyRequiresMergedMessage(t *testing.T) {
+	dir := t.TempDir()
+	cfg := protogen.Config{
+		SchemaPath: schemaFixture(),
+		Classes:    []string{"api_activity"},
+		Version:    "1.8.0",
+		OutDir:     dir,
+		TagmapPath: filepath.Join(dir, "field-numbers.json"),
+		MergedOnly: true,
+	}
+
+	_, err := protogen.Generate(cfg)
+	require.ErrorContains(t, err, "--merged-only requires --merged-message")
+}
+
 // TestGenerateSRSubjectRequiresMergedMessage verifies the flag dependency:
 // --merged-sr-subject without --merged-message is a configuration error.
 func TestGenerateSRSubjectRequiresMergedMessage(t *testing.T) {
@@ -811,6 +914,61 @@ func TestGenerateSRGoPackageOverride(t *testing.T) {
 	classGo, err := os.ReadFile(filepath.Join(srDir, "api_activity.sr.go"))
 	require.NoError(t, err)
 	require.Contains(t, string(classGo), "package auditschema\n")
+}
+
+// TestGenerateSRGoOnly verifies consumers can commit the Go schema embeds
+// without also retaining their intermediate .sr.proto inputs.
+func TestGenerateSRGoOnly(t *testing.T) {
+	dir := t.TempDir()
+	srDir := t.TempDir()
+
+	cfg := protogen.Config{
+		SchemaPath:      schemaFixture(),
+		Classes:         []string{"api_activity", "entity_management"},
+		Version:         "1.8.0",
+		OutDir:          dir,
+		TagmapPath:      filepath.Join(dir, "field-numbers.json"),
+		SRSchemaOutDir:  srDir,
+		MergedMessage:   "AuditEvent",
+		MergedSRSubject: "redpanda.ocsf.audit-events-value",
+		SRGoOnly:        true,
+	}
+
+	_, err := protogen.Generate(cfg)
+	require.NoError(t, err)
+
+	for _, name := range []string{
+		"api_activity.sr.go",
+		"entity_management.sr.go",
+		"audit_event.sr.go",
+	} {
+		require.FileExists(t, filepath.Join(srDir, name))
+	}
+	for _, name := range []string{
+		"api_activity.sr.proto",
+		"entity_management.sr.proto",
+		"audit_event.sr.proto",
+	} {
+		require.NoFileExists(t, filepath.Join(srDir, name))
+	}
+
+	checkCfg := cfg
+	checkCfg.Check = true
+	require.NoError(t, protogen.Check(checkCfg))
+}
+
+func TestGenerateSRGoOnlyRequiresSchemaOut(t *testing.T) {
+	cfg := protogen.Config{
+		SchemaPath: schemaFixture(),
+		Classes:    []string{"api_activity"},
+		Version:    "1.8.0",
+		OutDir:     t.TempDir(),
+		TagmapPath: filepath.Join(t.TempDir(), "field-numbers.json"),
+		SRGoOnly:   true,
+	}
+
+	_, err := protogen.Generate(cfg)
+	require.ErrorContains(t, err, "--sr-go-only requires --sr-schema-out")
 }
 
 // TestCheckFailsOnStraySRGo verifies --check detects a committed *.sr.go the

--- a/ocsf/go.mod
+++ b/ocsf/go.mod
@@ -8,6 +8,7 @@ require (
 	buf.build/go/protovalidate v1.0.0
 	github.com/stretchr/testify v1.11.1
 	google.golang.org/protobuf v1.36.11
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -21,5 +22,4 @@ require (
 	golang.org/x/text v0.28.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250811230008-5f3141c8851a // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250811230008-5f3141c8851a // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/ocsf/internal/ocsf/gen/emit.go
+++ b/ocsf/internal/ocsf/gen/emit.go
@@ -198,6 +198,26 @@ type GeneratedFile struct {
 // objectsFileName is the base name of the shared objects file.
 const objectsFileName = "objects.proto"
 
+// IsManagedOutputArtifact reports whether base is the name of a file this
+// generator owns inside a versioned output directory (<out>/ocsf/v<N>/).
+//
+// Generation reconciles those directories — a file matching this predicate that
+// the current run no longer produces is removed, so switching to a narrower
+// layout (--merged-only, --mask-file) does not leave strays behind for --check
+// to reject. Everything else in the output tree (buf.yaml, buf.lock, the
+// tagmap) is never touched.
+func IsManagedOutputArtifact(base string) bool {
+	return strings.HasSuffix(base, ".proto") ||
+		base == PruneSidecarName ||
+		base == MaskReportName
+}
+
+// IsManagedSRArtifact reports the same for the flat --sr-schema-out directory,
+// which holds only the self-contained SR schemas and their Go embeds.
+func IsManagedSRArtifact(base string) bool {
+	return strings.HasSuffix(base, ".sr.proto") || strings.HasSuffix(base, ".sr.go")
+}
+
 // Emit produces a deterministic multi-file proto3 layout from the named classes
 // and their transitive object closure.
 //

--- a/ocsf/internal/ocsf/gen/mask.go
+++ b/ocsf/internal/ocsf/gen/mask.go
@@ -73,6 +73,21 @@ func ParseMask(data []byte) (*Mask, error) {
 		return nil, fmt.Errorf("ocsf mask: parse: %w", err)
 	}
 
+	// Decode consumes ONE document. Without this, a second "---" document is
+	// silently ignored, which would let a typo'd key (or a whole second policy)
+	// slip past KnownFields and the path validation below — the opposite of the
+	// fail-closed behaviour a mask is supposed to have.
+	var trailing yaml.Node
+	switch err := dec.Decode(&trailing); {
+	case errors.Is(err, io.EOF):
+		// Exactly one document, as required.
+	case err == nil:
+		return nil, errors.New("ocsf mask: file has more than one YAML document; " +
+			"the mask must be a single document (no \"---\" separators)")
+	default:
+		return nil, fmt.Errorf("ocsf mask: parse trailing document: %w", err)
+	}
+
 	if raw.Version != maskFormatVersion {
 		return nil, fmt.Errorf("ocsf mask: unsupported version %d (want %d)", raw.Version, maskFormatVersion)
 	}
@@ -265,8 +280,8 @@ func VerifyMergedDiscriminators(s *schema.Schema, classNames []string) error {
 	return nil
 }
 
-// maskReportName is the base name of the sidecar recording the resolved mask.
-const maskReportName = "read-mask-report.txt"
+// MaskReportName is the base name of the sidecar recording the resolved mask.
+const MaskReportName = "read-mask-report.txt"
 
 // MaskReportFile renders the deterministic sidecar describing what the mask
 // kept. It lands next to the emitted protos (ocsf/v<N>/read-mask-report.txt).
@@ -310,7 +325,7 @@ func MaskReportFile(version string, res *MaskResult) (GeneratedFile, error) {
 		sb.WriteString(p + "\n")
 	}
 
-	return GeneratedFile{Path: "ocsf/" + pkgSuffix + "/" + maskReportName, Content: sb.String()}, nil
+	return GeneratedFile{Path: "ocsf/" + pkgSuffix + "/" + MaskReportName, Content: sb.String()}, nil
 }
 
 // ---------------------------------------------------------------------------
@@ -437,6 +452,19 @@ func (k *keepSet) descend(
 	s *schema.Schema, owner msgKey, attr *schema.Attribute,
 	path, consumed string, rest []string, wholeSubtree bool,
 ) error {
+	// messageEdge deliberately treats a reference to an object the snapshot does
+	// not define as a non-edge, because it emits as an empty stub message. That
+	// would make a mask path ending there look like a scalar terminal and let the
+	// mask produce `message Phantom {}` — so reject it explicitly instead, naming
+	// the missing type.
+	if missing, ok := absentObjectTarget(s, attr); ok {
+		return fmt.Errorf(
+			"ocsf mask: path %q reaches %q, whose object type %s is absent from the schema "+
+				"snapshot and would emit as an empty message; re-run with a full schema export "+
+				"or drop the path",
+			path, consumed, toPascalCase(missing))
+	}
+
 	target, isEdge := messageEdge(s, attr)
 
 	if len(rest) == 0 {
@@ -474,6 +502,23 @@ func (k *keepSet) descend(
 	nextOwner := msgKey{name: target}
 	k.keep(nextOwner, next)
 	return k.descend(s, nextOwner, nextAttr, path, consumed+"."+next, rest[1:], wholeSubtree)
+}
+
+// absentObjectTarget returns the referenced object name when attr is an object_t
+// reference to a named, non-generic object that the schema snapshot does not
+// define. Those emit as empty stub messages, so messageEdge classifies them as
+// non-edges; mask resolution has to tell them apart from real scalars.
+//
+// The generic "object" bag is excluded: it legitimately maps to a scalar (R1
+// demotes it to a JSON string), so a path may end on it.
+func absentObjectTarget(s *schema.Schema, attr *schema.Attribute) (string, bool) {
+	if attr.Type != objectTypeName || attr.ObjectType == "" || attr.ObjectType == genericObject {
+		return "", false
+	}
+	if _, defined := s.Objects[attr.ObjectType]; defined {
+		return "", false
+	}
+	return attr.ObjectType, true
 }
 
 // keep records that owner retains attr.

--- a/ocsf/internal/ocsf/gen/mask.go
+++ b/ocsf/internal/ocsf/gen/mask.go
@@ -1,0 +1,666 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package gen
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/redpanda-data/common-go/ocsf/internal/ocsf/schema"
+)
+
+// maskFormatVersion is the mask-file `version` this generator understands.
+// It gates the file format, not the OCSF schema version.
+const maskFormatVersion = 1
+
+// maskWildcard is the trailing path segment that keeps a message-typed field's
+// entire subtree rather than one scalar leaf.
+const maskWildcard = "*"
+
+// Mask is a parsed read mask: the set of root-relative dotted attribute paths a
+// consumer publishes. Everything not named (directly or under a "*" subtree) is
+// dropped from the emitted schema.
+//
+// A mask is an ALLOWLIST, deliberately: OCSF grows, and an allowlist keeps the
+// published contract the same size across schema bumps, where a denylist
+// silently regrows. The cost is that a renamed OCSF attribute stops matching,
+// which MaskFields reports as an error rather than silently narrowing the
+// output.
+type Mask struct {
+	// Paths are the root-relative dotted attribute paths to keep, sorted and
+	// deduplicated, as written (a subtree path keeps its trailing ".*").
+	//
+	// Paths are relative to a class root, e.g. "actor.user.email_addr". A path
+	// ending in ".*" keeps the named message-typed field and everything beneath
+	// it; any other path must end on a scalar.
+	Paths []string
+}
+
+// ParseMask decodes a read-mask YAML document:
+//
+//	version: 1
+//	paths:
+//	  - time
+//	  - actor.user.email_addr
+//	  - metadata.*
+//
+// Unknown keys are rejected so a typo fails generation instead of silently
+// widening the mask. The returned Mask has sorted, deduplicated paths.
+func ParseMask(data []byte) (*Mask, error) {
+	var raw struct {
+		Version int      `yaml:"version"`
+		Paths   []string `yaml:"paths"`
+	}
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	if err := dec.Decode(&raw); err != nil {
+		if errors.Is(err, io.EOF) {
+			return nil, errors.New("ocsf mask: file is empty")
+		}
+		return nil, fmt.Errorf("ocsf mask: parse: %w", err)
+	}
+
+	if raw.Version != maskFormatVersion {
+		return nil, fmt.Errorf("ocsf mask: unsupported version %d (want %d)", raw.Version, maskFormatVersion)
+	}
+	if len(raw.Paths) == 0 {
+		return nil, errors.New("ocsf mask: paths must be a non-empty list")
+	}
+
+	seen := make(map[string]bool, len(raw.Paths))
+	paths := make([]string, 0, len(raw.Paths))
+	for _, p := range raw.Paths {
+		p = strings.TrimSpace(p)
+		if err := validateMaskPath(p); err != nil {
+			return nil, err
+		}
+		if seen[p] {
+			continue
+		}
+		seen[p] = true
+		paths = append(paths, p)
+	}
+	sort.Strings(paths)
+
+	// A path already covered by a "*" subtree can never affect the output;
+	// keeping it would also make the widening report misleading (the path would
+	// look "asked for" via two different entries). Flag it as an authoring bug.
+	for _, p := range paths {
+		if err := checkNotSubsumed(p, paths); err != nil {
+			return nil, err
+		}
+	}
+
+	return &Mask{Paths: paths}, nil
+}
+
+// KeptField is one field the mask retains, in the same (Message, Field) shape
+// PrunedField uses so the two sidecars read alike.
+type KeptField struct {
+	// Message is the emitted proto message name that owns the field
+	// (PascalCase class or object name).
+	Message string
+	// Field is the proto field name (= OCSF attribute name).
+	Field string
+	// Subtree is true when the field was kept by a "*" path, meaning its whole
+	// target type is retained unmasked.
+	Subtree bool
+}
+
+// MaskStats records the size of the model either side of the mask. The leaf-path
+// counts are what an Iceberg/Oxla reader sees as columns, so they are the
+// numbers worth watching across OCSF bumps.
+type MaskStats struct {
+	LeafPathsBefore, LeafPathsAfter int
+	MessagesBefore, MessagesAfter   int
+}
+
+// MaskResult is what MaskFields retained, plus what the type-scoped projection
+// kept beyond the paths that were asked for.
+type MaskResult struct {
+	// Kept is the resolved type-scoped keep set, sorted by (Message, Field).
+	Kept []KeptField
+	// Widened lists the dotted leaf paths present in the masked output that no
+	// mask path asked for, sorted. See MaskFields for why these arise.
+	Widened []string
+	// Stats records model size before and after masking.
+	Stats MaskStats
+}
+
+// MaskFields mutates s in place so only the attributes named by the mask
+// survive, and returns what was kept.
+//
+// It must run BEFORE PruneForIceberg. The prune rules react to the shape of the
+// model — R3 demotes edges because a dotted path overflows 63 chars, R4 drops
+// edges to emptied types — so masking first means the deep subtrees that force
+// those demotions are simply gone, and the surviving fields keep their typed
+// structure instead of collapsing to JSON strings.
+//
+// # Type-scoped semantics
+//
+// Mask paths are written root-relative ("actor.user.email_addr") because that is
+// how consumers think about the event, but they are APPLIED type-scoped: the
+// path above keeps User.email_addr on the User message wherever User is
+// embedded. The schema model is a graph of shared object types, so a per-path
+// mask would require specialising a type per embedding path — a message
+// explosion that would also break the tagmap's (message, attr) identity.
+//
+// The gap between the two is reported: every leaf path in the masked output that
+// no mask path asked for lands in MaskResult.Widened. In practice the gap is
+// small, because sharing falls away as paths are closed — a type embedded at
+// fifteen paths in the full schema is usually reachable by one after masking.
+//
+// # Wire stability
+//
+// Masking never renumbers. Excluded attributes are simply never Assign()ed, so
+// they keep their tagmap entries, the tagmap file does not shrink, --compat-check
+// stays clean, and un-masking a field later restores its original field number.
+//
+// Constraints (at_least_one / just_one) naming a dropped attribute are scrubbed,
+// so the emitted CEL never references a field that no longer exists.
+//
+// An error is returned when a class is unknown, when a mask path does not
+// resolve against the schema, or when masking would leave a reachable message
+// with no fields.
+func MaskFields(s *schema.Schema, classNames []string, m *Mask) (*MaskResult, error) {
+	classes, err := maskClasses(s, classNames)
+	if err != nil {
+		return nil, err
+	}
+
+	stats := MaskStats{
+		LeafPathsBefore: len(leafPaths(s, classes)),
+		MessagesBefore:  len(reachableObjectNames(s, classes)) + len(classes),
+	}
+
+	keep, err := resolveMask(s, classes, m)
+	if err != nil {
+		return nil, err
+	}
+
+	// Snapshot reachability BEFORE mutating: an object that becomes unreachable
+	// is left untouched (SelectClosure simply stops emitting it), but it must
+	// still be visited here so a retained type reached only through it is masked
+	// consistently.
+	reachable := reachableObjectNames(s, classes)
+
+	for _, cls := range classes {
+		kept := keep.attrs[msgKey{isClass: true, name: cls.Name}]
+		for _, attrName := range sortedKeys(cls.Attributes) {
+			if !kept[attrName] {
+				dropClassField(cls, attrName)
+			}
+		}
+	}
+	for _, objName := range reachable {
+		if keep.subtree[objName] {
+			continue // kept whole by a "*" path
+		}
+		kept, masked := keep.attrs[msgKey{name: objName}]
+		if !masked {
+			continue // unreachable after masking; nothing to trim
+		}
+		obj := s.Objects[objName]
+		for _, attrName := range sortedKeys(obj.Attributes) {
+			if !kept[attrName] {
+				dropObjectField(obj, attrName)
+			}
+		}
+	}
+
+	if err := verifyMaskInvariants(s, classes); err != nil {
+		return nil, err
+	}
+
+	after := leafPaths(s, classes)
+	stats.LeafPathsAfter = len(after)
+	stats.MessagesAfter = len(reachableObjectNames(s, classes)) + len(classes)
+
+	return &MaskResult{
+		Kept:    keep.keptFields(s),
+		Widened: widenedPaths(after, m),
+		Stats:   stats,
+	}, nil
+}
+
+// mergedDiscriminators are the attributes a merged single-topic event message
+// cannot lose. The merged emitter gates per-class ownership, conditional
+// requiredness and per-class constraints on `this.class_uid` unconditionally, so
+// masking class_uid away emits CEL referencing a missing field; category_uid and
+// type_uid are how a reader of the single topic demuxes the class.
+var mergedDiscriminators = []string{"category_uid", "class_uid", "type_uid"}
+
+// VerifyMergedDiscriminators checks that every selected class still carries the
+// attributes a merged event message needs after masking. Callers apply it only
+// when emitting a merged message.
+func VerifyMergedDiscriminators(s *schema.Schema, classNames []string) error {
+	classes, err := maskClasses(s, classNames)
+	if err != nil {
+		return err
+	}
+	for _, cls := range classes {
+		for _, attrName := range mergedDiscriminators {
+			if _, ok := cls.Attributes[attrName]; !ok {
+				return fmt.Errorf(
+					"ocsf mask: class %q lost %q, which a merged event message requires "+
+						"(the merged emitter gates its CEL on class_uid, and readers demux the "+
+						"single topic on category_uid/class_uid/type_uid) — add %q to the mask",
+					cls.Name, attrName, attrName)
+			}
+		}
+	}
+	return nil
+}
+
+// maskReportName is the base name of the sidecar recording the resolved mask.
+const maskReportName = "read-mask-report.txt"
+
+// MaskReportFile renders the deterministic sidecar describing what the mask
+// kept. It lands next to the emitted protos (ocsf/v<N>/read-mask-report.txt).
+//
+// It lists the KEPT set rather than the dropped one: the kept set is the
+// published contract (tens of lines), where the dropped set is the whole rest of
+// OCSF (thousands). The widening section is the part worth reviewing — it names
+// every column the type-scoped projection produced that no mask path asked for.
+func MaskReportFile(version string, res *MaskResult) (GeneratedFile, error) {
+	pkgSuffix, err := versionToPackage(version)
+	if err != nil {
+		return GeneratedFile{}, err
+	}
+
+	var sb strings.Builder
+	sb.WriteString("# Code generated by ocsf-protogen --mask-file. DO NOT EDIT.\n")
+	sb.WriteString("# Source: OCSF schema " + version + "\n")
+	sb.WriteString("#\n")
+	sb.WriteString("# Effect of the mask alone, measured on the model as loaded (before any\n")
+	sb.WriteString("# --iceberg-compat pruning, which narrows it further):\n")
+	fmt.Fprintf(&sb, "#   leaf columns:  %d -> %d\n", res.Stats.LeafPathsBefore, res.Stats.LeafPathsAfter)
+	fmt.Fprintf(&sb, "#   message types: %d -> %d\n", res.Stats.MessagesBefore, res.Stats.MessagesAfter)
+	sb.WriteString("#\n")
+	sb.WriteString("# Fields kept by the mask: <Message>.<field>, with [subtree] where a \"*\"\n")
+	sb.WriteString("# path kept the field's whole target type. Everything else was dropped.\n")
+	for _, k := range res.Kept {
+		sb.WriteString(k.Message + "." + k.Field)
+		if k.Subtree {
+			sb.WriteString(" [subtree]")
+		}
+		sb.WriteString("\n")
+	}
+
+	sb.WriteString("\n# Widening: leaf columns no mask path asked for, kept because the mask is\n")
+	sb.WriteString("# applied per message type and these types are embedded at more than one\n")
+	sb.WriteString("# path. Review these — they are part of the published contract.\n")
+	if len(res.Widened) == 0 {
+		sb.WriteString("# (none)\n")
+	}
+	for _, p := range res.Widened {
+		sb.WriteString(p + "\n")
+	}
+
+	return GeneratedFile{Path: "ocsf/" + pkgSuffix + "/" + maskReportName, Content: sb.String()}, nil
+}
+
+// ---------------------------------------------------------------------------
+// Mask path validation
+// ---------------------------------------------------------------------------
+
+// validateMaskPath rejects paths that cannot be resolved structurally, before
+// any schema lookup: empty paths or segments, and "*" anywhere but last.
+func validateMaskPath(path string) error {
+	if path == "" {
+		return errors.New("ocsf mask: empty path")
+	}
+	segs := strings.Split(path, ".")
+	for i, seg := range segs {
+		if seg == "" {
+			return fmt.Errorf("ocsf mask: path %q has an empty segment", path)
+		}
+		if seg == maskWildcard && i != len(segs)-1 {
+			return fmt.Errorf("ocsf mask: path %q may only use %q as its final segment", path, maskWildcard)
+		}
+	}
+	if segs[0] == maskWildcard {
+		return fmt.Errorf("ocsf mask: path %q must name a class attribute before %q", path, maskWildcard)
+	}
+	return nil
+}
+
+// checkNotSubsumed returns an error when path is already covered by a different
+// "*" subtree path in paths.
+func checkNotSubsumed(path string, paths []string) error {
+	for _, other := range paths {
+		if other == path || !strings.HasSuffix(other, "."+maskWildcard) {
+			continue
+		}
+		prefix := strings.TrimSuffix(other, "."+maskWildcard)
+		if path == prefix || strings.HasPrefix(path, prefix+".") {
+			return fmt.Errorf("ocsf mask: path %q is already covered by %q; remove one", path, other)
+		}
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Mask resolution
+// ---------------------------------------------------------------------------
+
+// msgKey identifies a message in the schema model. A class and an object may
+// share a name, so the kind is part of the identity.
+type msgKey struct {
+	isClass bool
+	name    string
+}
+
+// keepSet is a resolved mask: per-message attribute allowlists, plus the objects
+// a "*" path retains whole.
+type keepSet struct {
+	attrs   map[msgKey]map[string]bool
+	subtree map[string]bool
+	// subtreeEdges records the (owner, attr) edges a "*" path terminated on, so
+	// the report can mark them.
+	subtreeEdges map[msgKey]map[string]bool
+}
+
+// resolveMask walks every mask path through the schema, recording the attribute
+// each step keeps. A path that does not resolve is an error: an allowlist that
+// silently stops matching would quietly shrink the published contract on an OCSF
+// bump, which is exactly the failure a mask is supposed to make loud.
+func resolveMask(s *schema.Schema, classes []*schema.Class, m *Mask) (*keepSet, error) {
+	keep := &keepSet{
+		attrs:        make(map[msgKey]map[string]bool),
+		subtree:      make(map[string]bool),
+		subtreeEdges: make(map[msgKey]map[string]bool),
+	}
+	for _, path := range m.Paths {
+		if err := keep.addPath(s, classes, path); err != nil {
+			return nil, err
+		}
+	}
+	// A "*" subtree keeps everything below it, so any type reachable from it is
+	// retained whole too. Done after all paths resolve so the marking sees the
+	// full set of subtree roots.
+	for _, root := range sortedBoolKeys(keep.subtree) {
+		keep.markSubtree(s, root)
+	}
+	return keep, nil
+}
+
+// addPath resolves one mask path and records every attribute it keeps.
+func (k *keepSet) addPath(s *schema.Schema, classes []*schema.Class, path string) error {
+	segs := strings.Split(path, ".")
+	wholeSubtree := segs[len(segs)-1] == maskWildcard
+	if wholeSubtree {
+		segs = segs[:len(segs)-1]
+	}
+
+	// The first segment addresses a class attribute. It applies to every
+	// selected class that has it — the merged message is the union of the
+	// classes, so a path naming a base_event attribute must reach all of them.
+	matched := false
+	for _, cls := range classes {
+		attr, ok := cls.Attributes[segs[0]]
+		if !ok {
+			continue
+		}
+		matched = true
+		owner := msgKey{isClass: true, name: cls.Name}
+		k.keep(owner, segs[0])
+		if err := k.descend(s, owner, attr, path, segs[0], segs[1:], wholeSubtree); err != nil {
+			return err
+		}
+	}
+	if !matched {
+		return fmt.Errorf(
+			"ocsf mask: path %q does not resolve: no selected class has attribute %q",
+			path, segs[0])
+	}
+	return nil
+}
+
+// descend walks the remaining segments of a mask path from attr, recording the
+// attribute kept at each step. owner/consumed describe where the walk currently
+// is, for error messages.
+func (k *keepSet) descend(
+	s *schema.Schema, owner msgKey, attr *schema.Attribute,
+	path, consumed string, rest []string, wholeSubtree bool,
+) error {
+	target, isEdge := messageEdge(s, attr)
+
+	if len(rest) == 0 {
+		switch {
+		case wholeSubtree && !isEdge:
+			return fmt.Errorf(
+				"ocsf mask: path %q uses %q but %q is not a message-typed field; drop the %q",
+				path, maskWildcard, consumed, maskWildcard)
+		case wholeSubtree:
+			k.subtree[target] = true
+			k.markSubtreeEdge(owner, attr.Name)
+		case isEdge:
+			return fmt.Errorf(
+				"ocsf mask: path %q ends on message-typed field %q (type %s); "+
+					"extend the path to a scalar or write %q to keep the whole subtree",
+				path, consumed, toPascalCase(target), consumed+"."+maskWildcard)
+		default:
+			// Ends on a scalar, which addPath/descend already recorded.
+		}
+		return nil
+	}
+
+	if !isEdge {
+		return fmt.Errorf(
+			"ocsf mask: path %q cannot descend past %q: it is not a message-typed field",
+			path, consumed)
+	}
+	next := rest[0]
+	nextAttr, ok := s.Objects[target].Attributes[next]
+	if !ok {
+		return fmt.Errorf(
+			"ocsf mask: path %q does not resolve: message %s (at %q) has no attribute %q",
+			path, toPascalCase(target), consumed, next)
+	}
+	nextOwner := msgKey{name: target}
+	k.keep(nextOwner, next)
+	return k.descend(s, nextOwner, nextAttr, path, consumed+"."+next, rest[1:], wholeSubtree)
+}
+
+// keep records that owner retains attr.
+func (k *keepSet) keep(owner msgKey, attr string) {
+	if k.attrs[owner] == nil {
+		k.attrs[owner] = make(map[string]bool)
+	}
+	k.attrs[owner][attr] = true
+}
+
+// markSubtreeEdge records that (owner, attr) is where a "*" path terminated.
+func (k *keepSet) markSubtreeEdge(owner msgKey, attr string) {
+	if k.subtreeEdges[owner] == nil {
+		k.subtreeEdges[owner] = make(map[string]bool)
+	}
+	k.subtreeEdges[owner][attr] = true
+}
+
+// markSubtree marks root and every object reachable from it as retained whole.
+func (k *keepSet) markSubtree(s *schema.Schema, root string) {
+	queue := []string{root}
+	for len(queue) > 0 {
+		name := queue[0]
+		queue = queue[1:]
+		obj, ok := s.Objects[name]
+		if !ok {
+			continue
+		}
+		for _, attrName := range sortedKeys(obj.Attributes) {
+			target, isEdge := messageEdge(s, obj.Attributes[attrName])
+			if !isEdge || k.subtree[target] {
+				continue
+			}
+			k.subtree[target] = true
+			queue = append(queue, target)
+		}
+	}
+}
+
+// keptFields flattens the keep set into the sorted report shape. Objects
+// retained whole by a "*" path contribute all their surviving attributes.
+func (k *keepSet) keptFields(s *schema.Schema) []KeptField {
+	var kept []KeptField
+	add := func(msgName string, attrs []string, subtreeEdges map[string]bool) {
+		for _, attrName := range attrs {
+			kept = append(kept, KeptField{
+				Message: msgName,
+				Field:   attrName,
+				Subtree: subtreeEdges[attrName],
+			})
+		}
+	}
+	for owner, attrs := range k.attrs {
+		if !owner.isClass && k.subtree[owner.name] {
+			continue // covered by the subtree pass below
+		}
+		add(toPascalCase(owner.name), sortedBoolKeys(attrs), k.subtreeEdges[owner])
+	}
+	for _, objName := range sortedBoolKeys(k.subtree) {
+		obj, ok := s.Objects[objName]
+		if !ok {
+			continue
+		}
+		add(toPascalCase(objName), sortedKeys(obj.Attributes), nil)
+	}
+
+	sort.Slice(kept, func(i, j int) bool {
+		if kept[i].Message != kept[j].Message {
+			return kept[i].Message < kept[j].Message
+		}
+		return kept[i].Field < kept[j].Field
+	})
+	return kept
+}
+
+// ---------------------------------------------------------------------------
+// Post-conditions, stats and widening
+// ---------------------------------------------------------------------------
+
+// verifyMaskInvariants checks the masked model is emittable: no class and no
+// reachable object may be left without fields. By construction a type is only
+// reachable after masking because a path kept an attribute on it, so a violation
+// is a resolver bug and must fail generation rather than emit an empty message.
+func verifyMaskInvariants(s *schema.Schema, classes []*schema.Class) error {
+	for _, cls := range classes {
+		if len(cls.Attributes) == 0 {
+			return fmt.Errorf("ocsf mask: class %q has no fields left; widen the mask", cls.Name)
+		}
+	}
+	for _, objName := range reachableObjectNames(s, classes) {
+		if len(s.Objects[objName].Attributes) == 0 {
+			return fmt.Errorf(
+				"ocsf mask: message %q is still reachable but has no fields left; widen the mask",
+				toPascalCase(objName))
+		}
+	}
+	return nil
+}
+
+// leafPaths returns every distinct dotted scalar-leaf path reachable from the
+// selected classes, sorted — the columns an Iceberg/Oxla reader sees.
+//
+// The pre-mask model may still be cyclic (masking runs before R2), so an edge
+// back to a type already on the current path is counted as a leaf at that edge,
+// which is what R2's demotion to a JSON string will make it.
+func leafPaths(s *schema.Schema, classes []*schema.Class) []string {
+	seen := make(map[string]bool)
+
+	var walk func(attrs map[string]*schema.Attribute, prefix string, stack map[string]bool)
+	walk = func(attrs map[string]*schema.Attribute, prefix string, stack map[string]bool) {
+		for _, attrName := range sortedKeys(attrs) {
+			path := attrName
+			if prefix != "" {
+				path = prefix + "." + attrName
+			}
+			target, isEdge := messageEdge(s, attrs[attrName])
+			if !isEdge || stack[target] {
+				seen[path] = true
+				continue
+			}
+			stack[target] = true
+			walk(s.Objects[target].Attributes, path, stack)
+			delete(stack, target)
+		}
+	}
+	for _, cls := range classes {
+		walk(cls.Attributes, "", map[string]bool{})
+	}
+
+	return sortedBoolKeys(seen)
+}
+
+// widenedPaths returns the leaf paths that no mask path asked for. These arise
+// where a type kept for one embedding is also reachable from another: the mask
+// is applied per type, so the fields come along at every surviving embedding.
+func widenedPaths(leaves []string, m *Mask) []string {
+	var widened []string
+	for _, leaf := range leaves {
+		if !maskAsksFor(leaf, m) {
+			widened = append(widened, leaf)
+		}
+	}
+	return widened
+}
+
+// maskAsksFor reports whether some mask path names leaf explicitly or covers it
+// with a "*" subtree.
+func maskAsksFor(leaf string, m *Mask) bool {
+	for _, p := range m.Paths {
+		if p == leaf {
+			return true
+		}
+		if !strings.HasSuffix(p, "."+maskWildcard) {
+			continue
+		}
+		prefix := strings.TrimSuffix(p, "."+maskWildcard)
+		if leaf == prefix || strings.HasPrefix(leaf, prefix+".") {
+			return true
+		}
+	}
+	return false
+}
+
+// maskClasses resolves and sorts the selected classes, mirroring
+// PruneForIceberg's contract so both stages see the same roots in the same
+// order.
+func maskClasses(s *schema.Schema, classNames []string) ([]*schema.Class, error) {
+	classes := make([]*schema.Class, 0, len(classNames))
+	for _, name := range classNames {
+		cls, ok := s.Classes[name]
+		if !ok {
+			return nil, fmt.Errorf("ocsf mask: class %q not found in schema", name)
+		}
+		classes = append(classes, cls)
+	}
+	sort.Slice(classes, func(i, j int) bool { return classes[i].Name < classes[j].Name })
+	return classes, nil
+}
+
+// sortedBoolKeys returns the true-valued keys of m, sorted.
+func sortedBoolKeys(m map[string]bool) []string {
+	keys := make([]string, 0, len(m))
+	for k, v := range m {
+		if v {
+			keys = append(keys, k)
+		}
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/ocsf/internal/ocsf/gen/mask_test.go
+++ b/ocsf/internal/ocsf/gen/mask_test.go
@@ -1,0 +1,583 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package gen_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/common-go/ocsf/internal/ocsf/gen"
+	"github.com/redpanda-data/common-go/ocsf/internal/ocsf/schema"
+	"github.com/redpanda-data/common-go/ocsf/internal/ocsf/tagmap"
+)
+
+// maskYAML renders a mask file body from the given paths. Paths are quoted: a
+// bare "*" is a YAML alias, so an unquoted wildcard-only entry would fail to
+// parse as YAML before the mask validator ever saw it.
+func maskYAML(paths ...string) []byte {
+	var sb strings.Builder
+	sb.WriteString("version: 1\npaths:\n")
+	for _, p := range paths {
+		sb.WriteString("  - \"" + p + "\"\n")
+	}
+	return []byte(sb.String())
+}
+
+// mustMask parses a mask from paths, failing the test on error.
+func mustMask(t *testing.T, paths ...string) *gen.Mask {
+	t.Helper()
+	m, err := gen.ParseMask(maskYAML(paths...))
+	require.NoError(t, err)
+	return m
+}
+
+// maskSchema builds a schema with the given classes and objects. Unlike
+// pruneSchema it takes the whole class map, so multi-class masking (which is
+// what the merged event message exercises) can be tested.
+func maskSchema(classes map[string]*schema.Class, objects map[string]*schema.Object) *schema.Schema {
+	return &schema.Schema{
+		Version:              "1.8.0",
+		Classes:              classes,
+		Objects:              objects,
+		Types:                map[string]*schema.TypeDef{"string_t": {}, "integer_t": {}},
+		DictionaryAttributes: map[string]*schema.DictAttr{},
+	}
+}
+
+// keptNames flattens a result's keep set into "Message.field" strings.
+func keptNames(res *gen.MaskResult) []string {
+	out := make([]string, 0, len(res.Kept))
+	for _, k := range res.Kept {
+		name := k.Message + "." + k.Field
+		if k.Subtree {
+			name += " [subtree]"
+		}
+		out = append(out, name)
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// ParseMask
+// ---------------------------------------------------------------------------
+
+// TestParseMask_SortsAndDedupes verifies the parsed mask is normalised, so two
+// mask files listing the same paths in a different order generate identically.
+func TestParseMask_SortsAndDedupes(t *testing.T) {
+	m, err := gen.ParseMask(maskYAML("time", "actor.user.name", "time"))
+	require.NoError(t, err)
+	require.Equal(t, []string{"actor.user.name", "time"}, m.Paths)
+}
+
+func TestParseMask_RejectsUnsupportedVersion(t *testing.T) {
+	_, err := gen.ParseMask([]byte("version: 2\npaths:\n  - time\n"))
+	require.ErrorContains(t, err, "unsupported version 2")
+}
+
+func TestParseMask_RejectsEmptyFile(t *testing.T) {
+	_, err := gen.ParseMask(nil)
+	require.ErrorContains(t, err, "file is empty")
+}
+
+func TestParseMask_RejectsEmptyPaths(t *testing.T) {
+	_, err := gen.ParseMask([]byte("version: 1\npaths: []\n"))
+	require.ErrorContains(t, err, "non-empty list")
+}
+
+// TestParseMask_RejectsUnknownKey verifies a typo in the mask file fails
+// generation instead of being ignored — an ignored key would silently widen or
+// narrow the published contract.
+func TestParseMask_RejectsUnknownKey(t *testing.T) {
+	_, err := gen.ParseMask([]byte("version: 1\npath:\n  - time\n"))
+	require.ErrorContains(t, err, "field path not found")
+}
+
+func TestParseMask_RejectsWildcardMidPath(t *testing.T) {
+	_, err := gen.ParseMask(maskYAML("actor.*.name"))
+	require.ErrorContains(t, err, `only use "*" as its final segment`)
+}
+
+func TestParseMask_RejectsBareWildcard(t *testing.T) {
+	_, err := gen.ParseMask(maskYAML("*"))
+	require.ErrorContains(t, err, "must name a class attribute")
+}
+
+func TestParseMask_RejectsEmptySegment(t *testing.T) {
+	_, err := gen.ParseMask(maskYAML("actor..name"))
+	require.ErrorContains(t, err, "empty segment")
+}
+
+// TestParseMask_RejectsSubsumedPath verifies a path already covered by a "*"
+// subtree is an error: it cannot affect the output, and leaving it in would make
+// the widening report claim a column was asked for by two different entries.
+func TestParseMask_RejectsSubsumedPath(t *testing.T) {
+	_, err := gen.ParseMask(maskYAML("actor.*", "actor.user.name"))
+	require.ErrorContains(t, err, `is already covered by "actor.*"`)
+}
+
+// ---------------------------------------------------------------------------
+// MaskFields
+// ---------------------------------------------------------------------------
+
+// TestMaskFields_KeepsOnlyNamedPaths is the core case: named attributes survive
+// at every level, everything else goes, and the intermediate edge is retained
+// automatically (the mask is closed upward — callers list leaves, not prefixes).
+func TestMaskFields_KeepsOnlyNamedPaths(t *testing.T) {
+	s := maskSchema(
+		map[string]*schema.Class{
+			"root": {Name: "root", UID: 1001, Attributes: map[string]*schema.Attribute{
+				"time":  strAttr("time"),
+				"noise": strAttr("noise"),
+				"thing": objAttr("thing", "thing"),
+			}},
+		},
+		map[string]*schema.Object{
+			"thing": {Name: "thing", Attributes: map[string]*schema.Attribute{
+				"uid":  strAttr("uid"),
+				"junk": strAttr("junk"),
+			}},
+		},
+	)
+
+	res, err := gen.MaskFields(s, []string{"root"}, mustMask(t, "time", "thing.uid"))
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"time", "thing"}, sortedAttrNames(s.Classes["root"].Attributes, "time", "thing"))
+	require.NotContains(t, s.Classes["root"].Attributes, "noise")
+	require.Contains(t, s.Objects["thing"].Attributes, "uid")
+	require.NotContains(t, s.Objects["thing"].Attributes, "junk")
+
+	require.Equal(t, []string{"Root.thing", "Root.time", "Thing.uid"}, keptNames(res))
+	require.Empty(t, res.Widened)
+	require.Equal(t, 2, res.Stats.LeafPathsAfter) // time, thing.uid
+	require.Equal(t, 4, res.Stats.LeafPathsBefore)
+}
+
+// TestMaskFields_SubtreeWildcard verifies "*" keeps a message-typed field's whole
+// target type, including types reachable only through it.
+func TestMaskFields_SubtreeWildcard(t *testing.T) {
+	s := maskSchema(
+		map[string]*schema.Class{
+			"root": {Name: "root", UID: 1001, Attributes: map[string]*schema.Attribute{
+				"thing": objAttr("thing", "thing"),
+				"noise": strAttr("noise"),
+			}},
+		},
+		map[string]*schema.Object{
+			"thing": {Name: "thing", Attributes: map[string]*schema.Attribute{
+				"uid":   strAttr("uid"),
+				"junk":  strAttr("junk"),
+				"inner": objAttr("inner", "inner"),
+			}},
+			"inner": {Name: "inner", Attributes: map[string]*schema.Attribute{
+				"deep": strAttr("deep"),
+			}},
+		},
+	)
+
+	res, err := gen.MaskFields(s, []string{"root"}, mustMask(t, "thing.*"))
+	require.NoError(t, err)
+
+	require.Len(t, s.Objects["thing"].Attributes, 3, "subtree keeps every field")
+	require.Contains(t, s.Objects["inner"].Attributes, "deep", "subtree is transitive")
+	require.NotContains(t, s.Classes["root"].Attributes, "noise")
+
+	require.Equal(t, []string{
+		"Inner.deep", "Root.thing [subtree]", "Thing.inner", "Thing.junk", "Thing.uid",
+	}, keptNames(res))
+	require.Empty(t, res.Widened, `"*" asks for everything beneath it`)
+}
+
+// TestMaskFields_ScrubsConstraints verifies at_least_one/just_one lose their
+// references to dropped attributes, so the emitted CEL never names a field that
+// no longer exists.
+func TestMaskFields_ScrubsConstraints(t *testing.T) {
+	s := maskSchema(
+		map[string]*schema.Class{
+			"root": {
+				Name: "root", UID: 1001,
+				Attributes: map[string]*schema.Attribute{
+					"a": strAttr("a"),
+					"b": strAttr("b"),
+					"c": strAttr("c"),
+				},
+				Constraints: &schema.Constraints{AtLeastOne: []string{"a", "b"}, JustOne: []string{"b", "c"}},
+			},
+		},
+		nil,
+	)
+
+	_, err := gen.MaskFields(s, []string{"root"}, mustMask(t, "a"))
+	require.NoError(t, err)
+	require.Equal(t, &schema.Constraints{AtLeastOne: []string{"a"}}, s.Classes["root"].Constraints,
+		"just_one emptied entirely, so it is absent rather than present-but-empty")
+}
+
+// TestMaskFields_DropsUnreachableObjectsFromEmission verifies masking an edge
+// away removes its whole target type from the emitted objects.proto — the size
+// win is structural, not just fewer fields on retained messages.
+func TestMaskFields_DropsUnreachableObjectsFromEmission(t *testing.T) {
+	s := maskSchema(
+		map[string]*schema.Class{
+			"root": {Name: "root", UID: 1001, Attributes: map[string]*schema.Attribute{
+				"keep": objAttr("keep", "keeper"),
+				"drop": objAttr("drop", "dropper"),
+			}},
+		},
+		map[string]*schema.Object{
+			"keeper":  {Name: "keeper", Attributes: map[string]*schema.Attribute{"uid": strAttr("uid")}},
+			"dropper": {Name: "dropper", Attributes: map[string]*schema.Attribute{"uid": strAttr("uid")}},
+		},
+	)
+
+	res, err := gen.MaskFields(s, []string{"root"}, mustMask(t, "keep.uid"))
+	require.NoError(t, err)
+	require.Equal(t, 2, res.Stats.MessagesAfter, "root + keeper")
+	require.Equal(t, 3, res.Stats.MessagesBefore)
+
+	files, _, err := gen.Emit(s, []string{"root"}, tagmap.New(), "1.8.0")
+	require.NoError(t, err)
+	var objects string
+	for _, f := range files {
+		if strings.HasSuffix(f.Path, "objects.proto") {
+			objects = f.Content
+		}
+	}
+	require.Contains(t, objects, "message Keeper {")
+	require.NotContains(t, objects, "message Dropper")
+}
+
+// TestMaskFields_WideningReportsSharedType is the honest-semantics case. The
+// mask is applied per message TYPE, so asking for actor.user.name and
+// target.user.email keeps BOTH fields on the shared User type — which means
+// actor.user.email and target.user.name exist too, though neither was asked for.
+// Those extra columns are part of the published contract and must be reported.
+func TestMaskFields_WideningReportsSharedType(t *testing.T) {
+	s := maskSchema(
+		map[string]*schema.Class{
+			"root": {Name: "root", UID: 1001, Attributes: map[string]*schema.Attribute{
+				"actor":  objAttr("actor", "holder"),
+				"target": objAttr("target", "holder"),
+			}},
+		},
+		map[string]*schema.Object{
+			"holder": {Name: "holder", Attributes: map[string]*schema.Attribute{
+				"user": objAttr("user", "user"),
+			}},
+			"user": {Name: "user", Attributes: map[string]*schema.Attribute{
+				"name":  strAttr("name"),
+				"email": strAttr("email"),
+				"phone": strAttr("phone"),
+			}},
+		},
+	)
+
+	res, err := gen.MaskFields(s, []string{"root"}, mustMask(t, "actor.user.name", "target.user.email"))
+	require.NoError(t, err)
+	require.Equal(t, []string{"actor.user.email", "target.user.name"}, res.Widened,
+		"the shared User type carries both fields to both embeddings")
+	require.NotContains(t, s.Objects["user"].Attributes, "phone",
+		"the mask still narrows User — widening is not the same as giving up")
+}
+
+// TestMaskFields_NoWideningWhenSharingCollapses verifies the reassuring half of
+// the type-scoped trade-off: closing one embedding removes the sharing, so the
+// same field set reports no widening at all.
+func TestMaskFields_NoWideningWhenSharingCollapses(t *testing.T) {
+	s := maskSchema(
+		map[string]*schema.Class{
+			"root": {Name: "root", UID: 1001, Attributes: map[string]*schema.Attribute{
+				"actor":  objAttr("actor", "holder"),
+				"target": objAttr("target", "holder"),
+			}},
+		},
+		map[string]*schema.Object{
+			"holder": {Name: "holder", Attributes: map[string]*schema.Attribute{
+				"user": objAttr("user", "user"),
+			}},
+			"user": {Name: "user", Attributes: map[string]*schema.Attribute{
+				"name":  strAttr("name"),
+				"email": strAttr("email"),
+			}},
+		},
+	)
+
+	res, err := gen.MaskFields(s, []string{"root"}, mustMask(t, "actor.user.name"))
+	require.NoError(t, err)
+	require.Empty(t, res.Widened, "target was dropped, so User is reachable by one path only")
+	require.NotContains(t, s.Classes["root"].Attributes, "target")
+}
+
+// TestMaskFields_PreservesTagNumbers is the wire-stability guarantee: masking
+// does not renumber surviving fields, and the excluded attributes keep their
+// tagmap entries, so --compat-check stays clean and un-masking a field later
+// restores its original field number.
+func TestMaskFields_PreservesTagNumbers(t *testing.T) {
+	newSchema := func() *schema.Schema {
+		return maskSchema(
+			map[string]*schema.Class{
+				"root": {Name: "root", UID: 1001, Attributes: map[string]*schema.Attribute{
+					"aaa": strAttr("aaa"),
+					"bbb": strAttr("bbb"),
+					"ccc": strAttr("ccc"),
+				}},
+			},
+			nil,
+		)
+	}
+
+	// Baseline: emit the full schema so every attribute gets a tag.
+	full := tagmap.New()
+	_, _, err := gen.Emit(newSchema(), []string{"root"}, full, "1.8.0")
+	require.NoError(t, err)
+	bbbTag, ok := full.Tag("Root", "bbb")
+	require.True(t, ok)
+
+	// Now mask "bbb" away and emit through the SAME tagmap.
+	masked := newSchema()
+	_, err = gen.MaskFields(masked, []string{"root"}, mustMask(t, "aaa", "ccc"))
+	require.NoError(t, err)
+	_, _, err = gen.Emit(masked, []string{"root"}, full, "1.8.0")
+	require.NoError(t, err)
+
+	for _, attr := range []string{"aaa", "ccc"} {
+		before, _ := full.Tag("Root", attr)
+		require.NotZero(t, before, "surviving field %q keeps a tag", attr)
+	}
+	stillThere, ok := full.Tag("Root", "bbb")
+	require.True(t, ok, "a masked-away attribute keeps its tagmap entry")
+	require.Equal(t, bbbTag, stillThere, "and keeps its original number, so un-masking is free")
+	require.NoError(t, tagmap.CheckCompat(full, full))
+}
+
+// TestMaskFields_RunsBeforePruneKeepsStructure verifies the ordering pays off:
+// the deep subtree that would force an R3 demotion is gone, so the surviving
+// fields stay typed instead of collapsing to a JSON string.
+func TestMaskFields_RunsBeforePruneKeepsStructure(t *testing.T) {
+	// A leaf name chosen so the path fits under "shallow." (7+1+55 = 63, the
+	// limit) but overflows under "deep.nested." (4+1+6+1+55 = 67). Only the deep
+	// embedding is unrepresentable.
+	deepName := strings.Repeat("z", 55)
+	newSchema := func() *schema.Schema {
+		return maskSchema(
+			map[string]*schema.Class{
+				"root": {Name: "root", UID: 1001, Attributes: map[string]*schema.Attribute{
+					"shallow": objAttr("shallow", "shared"),
+					"deep":    objAttr("deep", "wrapper"),
+				}},
+			},
+			map[string]*schema.Object{
+				"wrapper": {Name: "wrapper", Attributes: map[string]*schema.Attribute{
+					"nested": objAttr("nested", "shared"),
+				}},
+				"shared": {Name: "shared", Attributes: map[string]*schema.Attribute{
+					deepName: strAttr(deepName),
+				}},
+			},
+		)
+	}
+
+	// Without a mask the long path forces a prune.
+	unmasked, err := gen.PruneForIceberg(newSchema(), []string{"root"})
+	require.NoError(t, err)
+	require.NotEmpty(t, unmasked, "the deep embedding overflows the identifier limit")
+
+	// Masking the deep branch away first leaves nothing for the pruner to do.
+	s := newSchema()
+	_, err = gen.MaskFields(s, []string{"root"}, mustMask(t, "shallow."+deepName))
+	require.NoError(t, err)
+	prunes, err := gen.PruneForIceberg(s, []string{"root"})
+	require.NoError(t, err)
+	require.Empty(t, prunes, "the mask removed the reason for the R3 demotion")
+	require.Contains(t, s.Objects["shared"].Attributes, deepName)
+	require.Equal(t, "string_t", s.Objects["shared"].Attributes[deepName].Type,
+		"and the surviving field was never demoted")
+}
+
+// ---------------------------------------------------------------------------
+// MaskFields errors
+// ---------------------------------------------------------------------------
+
+// TestMaskFields_ErrUnresolvedPath is the guard that makes an allowlist safe
+// across OCSF bumps: a renamed attribute stops matching and fails generation
+// rather than silently dropping a column consumers query.
+func TestMaskFields_ErrUnresolvedPath(t *testing.T) {
+	s := maskSchema(
+		map[string]*schema.Class{
+			"root": {Name: "root", UID: 1001, Attributes: map[string]*schema.Attribute{"time": strAttr("time")}},
+		},
+		nil,
+	)
+	_, err := gen.MaskFields(s, []string{"root"}, mustMask(t, "time_of_day"))
+	require.ErrorContains(t, err, `no selected class has attribute "time_of_day"`)
+}
+
+func TestMaskFields_ErrUnknownNestedAttribute(t *testing.T) {
+	s := maskSchema(
+		map[string]*schema.Class{
+			"root": {Name: "root", UID: 1001, Attributes: map[string]*schema.Attribute{
+				"thing": objAttr("thing", "thing"),
+			}},
+		},
+		map[string]*schema.Object{
+			"thing": {Name: "thing", Attributes: map[string]*schema.Attribute{"uid": strAttr("uid")}},
+		},
+	)
+	_, err := gen.MaskFields(s, []string{"root"}, mustMask(t, "thing.nope"))
+	require.ErrorContains(t, err, `message Thing (at "thing") has no attribute "nope"`)
+}
+
+// TestMaskFields_ErrEndsOnMessageField verifies a path stopping on a
+// message-typed field is rejected with the fix in the message, rather than
+// silently emitting an empty message.
+func TestMaskFields_ErrEndsOnMessageField(t *testing.T) {
+	s := maskSchema(
+		map[string]*schema.Class{
+			"root": {Name: "root", UID: 1001, Attributes: map[string]*schema.Attribute{
+				"thing": objAttr("thing", "thing"),
+			}},
+		},
+		map[string]*schema.Object{
+			"thing": {Name: "thing", Attributes: map[string]*schema.Attribute{"uid": strAttr("uid")}},
+		},
+	)
+	_, err := gen.MaskFields(s, []string{"root"}, mustMask(t, "thing"))
+	require.ErrorContains(t, err, `write "thing.*" to keep the whole subtree`)
+}
+
+func TestMaskFields_ErrDescendPastScalar(t *testing.T) {
+	s := maskSchema(
+		map[string]*schema.Class{
+			"root": {Name: "root", UID: 1001, Attributes: map[string]*schema.Attribute{"time": strAttr("time")}},
+		},
+		nil,
+	)
+	_, err := gen.MaskFields(s, []string{"root"}, mustMask(t, "time.nested"))
+	require.ErrorContains(t, err, `cannot descend past "time"`)
+}
+
+func TestMaskFields_ErrWildcardOnScalar(t *testing.T) {
+	s := maskSchema(
+		map[string]*schema.Class{
+			"root": {Name: "root", UID: 1001, Attributes: map[string]*schema.Attribute{"time": strAttr("time")}},
+		},
+		nil,
+	)
+	_, err := gen.MaskFields(s, []string{"root"}, mustMask(t, "time.*"))
+	require.ErrorContains(t, err, `is not a message-typed field`)
+}
+
+// TestMaskFields_ErrClassEmptied verifies a mask naming nothing on one of the
+// selected classes fails rather than emitting a fieldless message.
+func TestMaskFields_ErrClassEmptied(t *testing.T) {
+	s := maskSchema(
+		map[string]*schema.Class{
+			"first":  {Name: "first", UID: 1001, Attributes: map[string]*schema.Attribute{"a": strAttr("a")}},
+			"second": {Name: "second", UID: 1002, Attributes: map[string]*schema.Attribute{"b": strAttr("b")}},
+		},
+		nil,
+	)
+	_, err := gen.MaskFields(s, []string{"first", "second"}, mustMask(t, "a"))
+	require.ErrorContains(t, err, `class "second" has no fields left`)
+}
+
+// TestMaskFields_AppliesToEverySelectedClass verifies a path naming a shared
+// (base_event) attribute is kept on every selected class, which is what the
+// merged event message's attribute union depends on.
+func TestMaskFields_AppliesToEverySelectedClass(t *testing.T) {
+	s := maskSchema(
+		map[string]*schema.Class{
+			"first": {Name: "first", UID: 1001, Attributes: map[string]*schema.Attribute{
+				"time": strAttr("time"), "noise": strAttr("noise"),
+			}},
+			"second": {Name: "second", UID: 1002, Attributes: map[string]*schema.Attribute{
+				"time": strAttr("time"), "other": strAttr("other"),
+			}},
+		},
+		nil,
+	)
+	_, err := gen.MaskFields(s, []string{"first", "second"}, mustMask(t, "time"))
+	require.NoError(t, err)
+	require.Equal(t, []string{"time"}, sortedAttrNames(s.Classes["first"].Attributes, "time"))
+	require.Equal(t, []string{"time"}, sortedAttrNames(s.Classes["second"].Attributes, "time"))
+}
+
+// ---------------------------------------------------------------------------
+// Merged discriminators and the report
+// ---------------------------------------------------------------------------
+
+// TestVerifyMergedDiscriminators verifies the guard on the merged emission's
+// hard dependency: its CEL gates on this.class_uid unconditionally, so a mask
+// that drops the discriminators would emit rules referencing missing fields.
+func TestVerifyMergedDiscriminators(t *testing.T) {
+	withAttrs := func(names ...string) *schema.Schema {
+		attrs := make(map[string]*schema.Attribute, len(names))
+		for _, n := range names {
+			attrs[n] = strAttr(n)
+		}
+		return maskSchema(
+			map[string]*schema.Class{"root": {Name: "root", UID: 1001, Attributes: attrs}},
+			nil,
+		)
+	}
+
+	require.NoError(t, gen.VerifyMergedDiscriminators(
+		withAttrs("category_uid", "class_uid", "type_uid", "time"), []string{"root"}))
+
+	err := gen.VerifyMergedDiscriminators(withAttrs("category_uid", "type_uid"), []string{"root"})
+	require.ErrorContains(t, err, `class "root" lost "class_uid"`)
+	require.ErrorContains(t, err, "add \"class_uid\" to the mask")
+}
+
+// TestMaskReportFile verifies the sidecar is deterministic and carries the
+// numbers worth watching across OCSF bumps.
+func TestMaskReportFile(t *testing.T) {
+	res := &gen.MaskResult{
+		Kept: []gen.KeptField{
+			{Message: "Root", Field: "thing", Subtree: true},
+			{Message: "Root", Field: "time"},
+		},
+		Widened: []string{"target.user.name"},
+		Stats:   gen.MaskStats{LeafPathsBefore: 3993, LeafPathsAfter: 51, MessagesBefore: 101, MessagesAfter: 15},
+	}
+
+	f, err := gen.MaskReportFile("1.8.0", res)
+	require.NoError(t, err)
+	require.Equal(t, "ocsf/v1/read-mask-report.txt", f.Path)
+	require.Contains(t, f.Content, "leaf columns:  3993 -> 51")
+	require.Contains(t, f.Content, "message types: 101 -> 15")
+	require.Contains(t, f.Content, "Root.thing [subtree]\n")
+	require.Contains(t, f.Content, "Root.time\n")
+	require.Contains(t, f.Content, "target.user.name\n")
+
+	again, err := gen.MaskReportFile("1.8.0", res)
+	require.NoError(t, err)
+	require.Equal(t, f.Content, again.Content)
+}
+
+func TestMaskReportFile_NoWidening(t *testing.T) {
+	f, err := gen.MaskReportFile("1.8.0", &gen.MaskResult{})
+	require.NoError(t, err)
+	require.Contains(t, f.Content, "# (none)")
+}
+
+// sortedAttrNames returns the wanted names that are present in attrs, in the
+// order given — a readable way to assert an exact surviving attribute set.
+func sortedAttrNames(attrs map[string]*schema.Attribute, want ...string) []string {
+	out := make([]string, 0, len(want))
+	for _, name := range want {
+		if _, ok := attrs[name]; ok {
+			out = append(out, name)
+		}
+	}
+	return out
+}

--- a/ocsf/internal/ocsf/gen/mask_test.go
+++ b/ocsf/internal/ocsf/gen/mask_test.go
@@ -581,3 +581,62 @@ func sortedAttrNames(attrs map[string]*schema.Attribute, want ...string) []strin
 	}
 	return out
 }
+
+// TestParseMask_RejectsMultipleDocuments verifies the parser consumes the whole
+// file. yaml.Decoder.Decode reads ONE document, so without an explicit EOF check
+// a second "---" document is silently ignored — which would let a typo'd key slip
+// past KnownFields and defeat the mask's fail-closed contract.
+func TestParseMask_RejectsMultipleDocuments(t *testing.T) {
+	_, err := gen.ParseMask([]byte("version: 1\npaths:\n  - time\n---\npaths_typo:\n  - nonsense\n"))
+	require.ErrorContains(t, err, "more than one YAML document")
+}
+
+// TestMaskFields_ErrAbsentObjectTarget covers the partial-export case: an
+// object_t attribute whose target the snapshot does not define emits as an empty
+// stub message, and messageEdge classifies it as a non-edge. Mask resolution must
+// not mistake that for a scalar terminal, or the mask silently produces
+// `message Phantom {}`.
+func TestMaskFields_ErrAbsentObjectTarget(t *testing.T) {
+	newSchema := func() *schema.Schema {
+		return maskSchema(
+			map[string]*schema.Class{
+				"root": {Name: "root", UID: 1001, Attributes: map[string]*schema.Attribute{
+					"time":    strAttr("time"),
+					"phantom": objAttr("phantom", "phantom"), // target absent
+				}},
+			},
+			map[string]*schema.Object{},
+		)
+	}
+
+	_, err := gen.MaskFields(newSchema(), []string{"root"}, mustMask(t, "time", "phantom"))
+	require.ErrorContains(t, err, "absent from the schema")
+	require.ErrorContains(t, err, "Phantom")
+
+	// The wildcard form is equally invalid — there is no subtree to keep.
+	_, err = gen.MaskFields(newSchema(), []string{"root"}, mustMask(t, "time", "phantom.*"))
+	require.ErrorContains(t, err, "absent from the schema")
+
+	// And descending through one names the missing type rather than reporting a
+	// missing attribute on it.
+	_, err = gen.MaskFields(newSchema(), []string{"root"}, mustMask(t, "time", "phantom.uid"))
+	require.ErrorContains(t, err, "absent from the schema")
+}
+
+// TestMaskFields_GenericObjectStillTerminates guards the other side of that
+// check: the generic "object" bag legitimately maps to a scalar (R1 demotes it to
+// a JSON string), so a path may end on it.
+func TestMaskFields_GenericObjectStillTerminates(t *testing.T) {
+	s := maskSchema(
+		map[string]*schema.Class{
+			"root": {Name: "root", UID: 1001, Attributes: map[string]*schema.Attribute{
+				"time":     strAttr("time"),
+				"unmapped": objAttr("unmapped", "object"), // generic bag
+			}},
+		},
+		map[string]*schema.Object{},
+	)
+	_, err := gen.MaskFields(s, []string{"root"}, mustMask(t, "time", "unmapped"))
+	require.NoError(t, err)
+	require.Contains(t, s.Classes["root"].Attributes, "unmapped")
+}

--- a/ocsf/internal/ocsf/gen/prune.go
+++ b/ocsf/internal/ocsf/gen/prune.go
@@ -178,8 +178,8 @@ func PruneForIceberg(s *schema.Schema, classNames []string) ([]PrunedField, erro
 	return prunes, nil
 }
 
-// pruneSidecarName is the base name of the sidecar file listing pruned fields.
-const pruneSidecarName = "iceberg-compat-prunes.txt"
+// PruneSidecarName is the base name of the sidecar file listing pruned fields.
+const PruneSidecarName = "iceberg-compat-prunes.txt"
 
 // PruneSidecarFile renders the deterministic sidecar recording what
 // --iceberg-compat pruned: one "<Message>.<field> <rule>" line per pruned
@@ -207,7 +207,7 @@ func PruneSidecarFile(version string, prunes []PrunedField) (GeneratedFile, erro
 	for _, line := range lines {
 		sb.WriteString(line + "\n")
 	}
-	return GeneratedFile{Path: "ocsf/" + pkgSuffix + "/" + pruneSidecarName, Content: sb.String()}, nil
+	return GeneratedFile{Path: "ocsf/" + pkgSuffix + "/" + PruneSidecarName, Content: sb.String()}, nil
 }
 
 // isValueAttr reports whether attr maps to google.protobuf.Value (R1).

--- a/ocsf/internal/ocsf/gen/reserve.go
+++ b/ocsf/internal/ocsf/gen/reserve.go
@@ -1,0 +1,97 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package gen
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/redpanda-data/common-go/ocsf/internal/ocsf/schema"
+	"github.com/redpanda-data/common-go/ocsf/internal/ocsf/tagmap"
+)
+
+// ReserveTags assigns a field number to every attribute of every message the
+// emitters can produce — the selected classes, their full object closure, and
+// the merged message's attribute union — and must run BEFORE anything narrows
+// the model (MaskFields, PruneForIceberg).
+//
+// It makes field numbers a function of the OCSF schema and the class selection
+// alone, never of what a mask or prune chose to emit.
+//
+// # Why this is needed
+//
+// tagmap.Assign hands out the lowest free number per message, so the numbers
+// depend on WHICH attributes it is asked about. Without this pass, bootstrapping
+// a tagmap while a mask is active walks only the retained attributes and
+// compacts them from 1: on the OCSF 1.8.0 audit-log mask every one of the 20
+// surviving AuditEvent fields moves (actor 7 -> 3, time 61 -> 19, type_uid
+// 66 -> 20). Nothing detects that, and every previously written record decodes
+// to an empty event.
+//
+// Reserving from the unmasked model instead means a from-scratch tagmap is
+// identical whether or not a mask is in play, so deleting the tagmap file is
+// recoverable rather than silently destructive. It also makes the
+// wire-stability contract structural rather than incidental: an excluded
+// attribute keeps its recorded number, so adding it back to the mask later
+// restores the number it always had.
+//
+// This does NOT emit anything. The tagmap is a build-time ledger of "what
+// number would this attribute get"; the mask alone decides which attributes
+// reach the generated protos.
+//
+// NOTE: the tagmap file remains the source of truth ACROSS OCSF versions —
+// reserving is deterministic only for a fixed schema. A new OCSF release that
+// inserts an alphabetically-early attribute shifts every later number, which is
+// exactly what the committed tagmap prevents. This pass removes the mask's
+// influence on numbering; it is not a substitute for committing the tagmap.
+//
+// Ordering matches emitMessage exactly (attributes sorted by name, per
+// message), so the numbers are the same ones the emitters would assign. Order
+// ACROSS messages is irrelevant: Assign allocates per message independently.
+func ReserveTags(s *schema.Schema, classNames []string, mergedMessage string, tm *tagmap.TagMap) error {
+	classes, objects, err := SelectClosure(s, classNames)
+	if err != nil {
+		return err
+	}
+
+	reserve := func(msgName string, attrs map[string]*schema.Attribute) error {
+		for _, attrName := range sortedKeys(attrs) {
+			if _, err := tm.Assign(msgName, attrName); err != nil {
+				return fmt.Errorf("ocsf reserve: %s.%s: %w", msgName, attrName, err)
+			}
+		}
+		return nil
+	}
+
+	for i := range classes {
+		if err := reserve(ClassMessageName(classes[i].Name), classes[i].Attributes); err != nil {
+			return err
+		}
+	}
+	for i := range objects {
+		if err := reserve(toPascalCase(objects[i].Name), objects[i].Attributes); err != nil {
+			return err
+		}
+	}
+
+	if strings.TrimSpace(mergedMessage) == "" {
+		return nil
+	}
+
+	// The merged message owns its own tag lineage, keyed by mergedMessage. Merge
+	// the UNMASKED classes so its numbering is likewise mask-independent. An
+	// error here means an unmasked run would fail too, so it is propagated
+	// rather than skipped.
+	merged, err := MergeClasses(s, classNames, mergedMessage)
+	if err != nil {
+		return fmt.Errorf("ocsf reserve: merge classes for %q: %w", mergedMessage, err)
+	}
+	return reserve(merged.Name, merged.Attributes)
+}


### PR DESCRIPTION
## What

- Add `--merged-only` to emit the merged event and shared objects without per-class proto or Schema Registry artifacts.
- Add `--sr-go-only` to retain generated Schema Registry Go embeds without their intermediate `.sr.proto` files.
- Add `--mask-file`: an allowlist of root-relative attribute paths (a "read mask") that narrows the schema model before any emission, plus a committed `ocsf/v<N>/read-mask-report.txt` sidecar recording the resolved keep set and any widening.
- Reserve field numbers over the *unmasked* model, so numbering never depends on what the mask or prune chose to emit.
- Reconcile the output directories on generate, so switching to a narrower layout no longer leaves strays behind.
- Apply the same output selection in native `--check`, including stray-file detection for the sidecars.

## Why

Consumers using one merged OCSF audit-log topic currently have to commit unused per-class schemas or maintain a local generate/filter/delete wrapper. Keeping output selection in `ocsf-protogen` lets cloudv2 and other consumers generate only the contract they publish while preserving deterministic generation, wire tags, Iceberg pruning, and native drift checks.

`--mask-file` addresses the other half of the same problem: the *contents* of that one topic. An OCSF class is far larger than any producer populates — `api_activity` + `entity_management` reach ~100 message types and ~14k leaf columns, of which cloudv2 writes 15 types and 60 fields. Every consumer pays for the rest, and an Iceberg-enabled topic pays for it per column on `REFRESH` and on compaction (Iceberg manifest entries carry per-column bounds and null counts for *every* column in the table schema).

Measured on cloudv2's exact invocation (`--classes api_activity,entity_management --merged-message AuditEvent --iceberg-compat`) with a mask of the fields it actually populates:

|  | unmasked | masked |
| --- | --- | --- |
| `objects.proto` | 2,569 lines, 101 messages | 136 lines, 14 messages |
| `audit_event.sr.proto` | 61,263 bytes | 4,857 bytes |
| leaf columns (pre-prune model) | 14,008 | 51 |
| `--iceberg-compat` demotions | 55 | 3 |

That last row is why the mask runs *before* the prune: the prune rules react to the shape of the model (R3 demotes an edge when a dotted path overflows 63 chars, R4 drops edges to emptied types), so removing the deep subtrees first leaves 52 fields typed instead of collapsed into JSON strings.

There is also a functional motivation, confirmed against a live stack: `SELECT *` on the ~4,000-column table **OOM-kills Oxla at an 8Gi limit** (reproduced repeatedly; `DESCRIBE ICEBERG TABLE` does the same). The equivalent 30–35 column tables in the same instance are fine, so width is the cause.

### Mask design notes

- Paths are written root-relative (`actor.user.email_addr`) but applied per message **type**, because the model is a graph of shared object types — a per-path mask would need a type specialised per embedding path, which explodes the message count and breaks the tagmap's `(message, attribute)` identity. Every leaf column the projection kept without being asked to is listed in the widening section of the report, so the gap is reviewable rather than hidden. It is usually empty: sharing falls away as paths are closed.
- A path ending in `.*` keeps a whole subtree (transitively); any other path must end on a scalar. Stopping on a message-typed field is an error that names the fix, so a mask cannot silently produce an empty message.
- An unresolvable path **fails generation**. That is the point of an allowlist: an OCSF rename cannot quietly narrow the published contract.
- Constraints (`at_least_one` / `just_one`) naming a dropped attribute are scrubbed, and the merged discriminators (`category_uid` / `class_uid` / `type_uid`) may not be masked away — `emitmerged.go` gates ownership, conditional requiredness and per-class constraint CEL on `this.class_uid` unconditionally, so dropping it would emit rules against a field that no longer exists.

### Wire stability: `gen.ReserveTags`

`tagmap.Assign` hands out the lowest free number per message, so the result depends on *which* attributes it is asked about. Bootstrapping a tagmap with a mask active walked only the retained attributes and compacted them from 1 — on the OCSF 1.8.0 audit-log mask **all 20 surviving `AuditEvent` fields moved** (`actor` 7→3, `metadata` 40→12, `time` 61→19, `type_uid` 66→20). Nothing detected it, and every record already written would decode to an empty event.

Tags are now reserved over the unmasked, unpruned model first, so field numbers are a function of the OCSF schema and the class selection alone. Verified through the CLI: a tagmap bootstrapped **with** a mask is byte-identical to one bootstrapped **without** it (1,481 entries each), and the masked protos keep the real sparse numbers (`actor = 7`, `metadata = 40`, `type_uid = 66`).

This makes the contract structural rather than incidental — un-masking a field later restores the number it always had, because the excluded attributes keep their recorded entries. It emits nothing new: the tagmap is a build-time ledger of what number an attribute *would* get, and the mask alone still decides what reaches the protos.

The tagmap must still be committed. Reserving is deterministic only for a *fixed* OCSF version: a release that inserts an alphabetically-early attribute would still shift every later number (adding `User.age` would move 20 of 21 `User` fields), and the committed tagmap is the only thing that prevents that. It is also the only record of `reserved` numbers that retired fields must never give up.

### Output reconciliation

Generation previously only wrote the selected files and never reconciled the destination directories, so switching an existing full baseline to `--merged-only` / `--sr-go-only` / `--mask-file` kept every per-class `.proto`, `.sr.proto` and `.sr.go` on disk. `--check` then failed on them as strays, and its own advice ("run without `--check` to regenerate") could not clear them — which blocked the main adoption path.

`writeFiles` becomes `syncFiles`: after writing, generator-managed artifacts in the directories written to that this run no longer produces are removed. Deletion is confined to those directories and to names the generator claims (`gen.IsManagedOutputArtifact` / `gen.IsManagedSRArtifact`), so `buf.yaml`, `buf.lock`, the tagmap and hand-added files are never candidates — asserted by a dedicated safety test.

Reconciliation covers the sidecars, and check mode now enumerates them too: dropping `--mask-file` previously left `read-mask-report.txt` in place *and* `--check` reported `ok`, because its stray scan only looked at `*.proto`.

### Two mask validation holes closed

- **Trailing YAML documents.** `ParseMask` decoded exactly one document, so a valid first document followed by `---` and a second containing an unknown key succeeded with the second silently ignored — defeating `KnownFields` and the path checks. It now requires `io.EOF` after the first document.
- **Missing object definitions.** `messageEdge` deliberately reports absent `object_t` targets as non-edges (they emit as empty stubs), so on a partial export a mask ending at such an attribute was accepted as if it ended on a scalar, and emission produced `message Phantom {}` — contradicting both the scalar-terminal rule and the no-empty-messages guarantee. Mask resolution now distinguishes an unresolved object reference from a scalar and names the missing type. The generic `"object"` bag still terminates legitimately, since R1 maps it to a string.

## Consumer split

The mask itself is consumer policy, not generator knowledge: which fields you publish belongs in your repo next to your committed output, the same way `--classes` and `--merged-message` do. See redpanda-data/cloudv2#28787 for the policy side.

This is also the generator-side prerequisite for a follow-up cleanup to redpanda-data/cloudv2#28534.

## Validation

- `go test ./...` from `ocsf/` — green
- `golangci-lint run` from `ocsf/` — 0 issues
- End-to-end generate and `--check` with `--merged-only --sr-go-only --iceberg-compat`; output contained only `audit_event.proto`, `objects.proto`, `iceberg-compat-prunes.txt`, and `audit_event.sr.go`.
- End-to-end generate and `--check` round trip with `--mask-file` on cloudv2's full flag set; the committed tagmap stays byte-identical after masking and `--compat-check` passes against the unmasked baseline.
- Fresh-tagmap bootstrap with and without a mask produces byte-identical `field-numbers.json`.
- Broad → narrow regeneration removes the previous layout's artifacts and `--check` passes immediately afterwards; unmanaged files in the same directories survive.
- Against a live stack: the emitted `.sr.proto` was accepted by a real Schema Registry and loaded by a real Oxla, which resolved the 51 narrow columns and correctly rejected the masked-away ones.
